### PR TITLE
fix: medios dropdowns use Estado=true boolean (BUG-01)

### DIFF
--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -229,8 +229,8 @@ async function fetchCatalogs() {
     apiGet('/programas').catch(() => []),
     apiGet('/periodos').catch(() => []),
     apiGet('/sedes').catch(() => []),
-    apiGet('/mediospublicitarios', { Estado: 'Activo' }).catch(() => []),
-    apiGet('/medioscontacto', { Estado: 'Activo' }).catch(() => [])
+    apiGet('/mediospublicitarios', { Estado: true }).catch(() => []),
+    apiGet('/medioscontacto', { Estado: true }).catch(() => [])
   ]);
   return {
     programas: Array.isArray(programas) ? programas : [],
@@ -315,8 +315,8 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 
     case 'fetchMedios':
       return handle(Promise.all([
-        apiGet('/mediospublicitarios', { Estado: 'Activo' }).catch(() => []),
-        apiGet('/medioscontacto', { Estado: 'Activo' }).catch(() => [])
+        apiGet('/mediospublicitarios', { Estado: true }).catch(() => []),
+        apiGet('/medioscontacto', { Estado: true }).catch(() => [])
       ]).then(([pub, ctc]) => ({ mediospublicitarios: pub, medioscontacto: ctc })));
 
     case 'createActividad':


### PR DESCRIPTION
## Summary
- Fixes the medios dropdowns (medio de contacto / medio publicitario) that were silently empty in the **create-oportunidad modal**
- Root cause: plugin was sending `?Estado=Activo` (string); Q10 API requires `?Estado=true` (boolean)
- Error was swallowed by `.catch(() => [])`, so users saw empty dropdowns with no error message

## Evidence (validated live against the real Q10 API, 2026-04-20)
| URL | Before | After |
|---|---|---|
| `GET /medioscontacto?Estado=Activo` | 400 `"The value 'Activo' is not valid for Nullable\`1"` | — |
| `GET /medioscontacto?Estado=true` | — | 200 `[{Nombre_medio_contacto: "Whatsapp"}]` |
| `GET /mediospublicitarios?Estado=true` | — | 200 `[Facebook, Instagram]` |
| Plugin's exact URL `?Limit=1000&Offset=1&Estado=true` | — | 200 (same data) |

## Scope of change
4 lines in `background/service-worker.js`:
- `fetchCatalogs()` — lines 232-233
- `fetchMedios` case handler — lines 318-319

## Test plan
- [ ] Reload extension in Chrome
- [ ] Open WhatsApp Web and side panel
- [ ] Trigger "create oportunidad" modal
- [ ] Verify **Medio de contacto** dropdown shows "Whatsapp"
- [ ] Verify **Medio publicitario** dropdown shows "Facebook" and "Instagram"
- [ ] Submit oportunidad successfully with a selected medio

## Follow-ups (out of scope, noted for future work)
- `.catch(() => [])` silently swallows API errors; should at least `console.warn` so similar regressions are visible
- `createEstudiante` handler posts to `/usuarios` but doc and live schema validation suggest `/estudiantes` is correct — needs separate investigation
- `Estado_actividad` / `Tipo_actividad` enums still unknown; required before implementing CRM activity logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)