### PR TITLE
fix: align payloads with Q10 official API (BUG-02..06)

### DIFF
--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -230,14 +230,16 @@ async function searchContacts({ phone, name }) {
 // ---------- Fetch catalogs ----------
 
 async function fetchCatalogs() {
-  const [programas, periodos, sedes, jornadas, niveles, tiposIdent, sexos, mediospublicitarios, medioscontacto] = await Promise.all([
+  const [programas, periodos, sedes, jornadas, sedesjornadas, niveles, tiposIdent, sexos, condicionesMat, mediospublicitarios, medioscontacto] = await Promise.all([
     apiGet('/programas').catch((e) => { console.warn('[Q10] /programas failed:', e.message); return []; }),
     apiGet('/periodos').catch((e) => { console.warn('[Q10] /periodos failed:', e.message); return []; }),
     apiGet('/sedes').catch((e) => { console.warn('[Q10] /sedes failed:', e.message); return []; }),
     apiGet('/jornadas').catch((e) => { console.warn('[Q10] /jornadas failed:', e.message); return []; }),
+    apiGet('/sedesjornadas').catch((e) => { console.warn('[Q10] /sedesjornadas failed:', e.message); return []; }),
     apiGet('/niveles', { Estado: true }).catch((e) => { console.warn('[Q10] /niveles failed:', e.message); return []; }),
     apiGet('/tiposidentificacion').catch((e) => { console.warn('[Q10] /tiposidentificacion failed:', e.message); return []; }),
     apiGet('/sexos').catch((e) => { console.warn('[Q10] /sexos failed:', e.message); return []; }),
+    apiGet('/condicionesMatricula', { Estado: true }).catch((e) => { console.warn('[Q10] /condicionesMatricula failed:', e.message); return []; }),
     apiGet('/mediospublicitarios', { Estado: true }).catch((e) => { console.warn('[Q10] /mediospublicitarios failed:', e.message); return []; }),
     apiGet('/medioscontacto', { Estado: true }).catch((e) => { console.warn('[Q10] /medioscontacto failed:', e.message); return []; })
   ]);
@@ -246,9 +248,11 @@ async function fetchCatalogs() {
     periodos: Array.isArray(periodos) ? periodos : [],
     sedes: Array.isArray(sedes) ? sedes : [],
     jornadas: Array.isArray(jornadas) ? jornadas : [],
+    sedesjornadas: Array.isArray(sedesjornadas) ? sedesjornadas : [],
     niveles: Array.isArray(niveles) ? niveles : [],
     tiposIdentificacion: Array.isArray(tiposIdent) ? tiposIdent : [],
     sexos: Array.isArray(sexos) ? sexos : [],
+    condicionesMatricula: Array.isArray(condicionesMat) ? condicionesMat : [],
     mediospublicitarios: Array.isArray(mediospublicitarios) ? mediospublicitarios : [],
     medioscontacto: Array.isArray(medioscontacto) ? medioscontacto : []
   };

--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -377,6 +377,10 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     case 'getAsesorId':
       return handle(getAsesorId().then(id => ({ asesorId: id })));
 
+    case 'fetchAdministrativos':
+      // Used by options page to populate the asesor dropdown. Cached 5 min via apiGet.
+      return handle(apiGet('/administrativos'));
+
     case 'exportAll':
       return handle((async () => {
         const [contactos, usuarios] = await Promise.all([

--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -40,6 +40,11 @@ async function getApiKey() {
   return result.q10ApiKey || null;
 }
 
+async function getAsesorId() {
+  const result = await chrome.storage.sync.get(['q10AsesorId']);
+  return result.q10AsesorId || null;
+}
+
 async function apiGet(endpoint, params = {}, opts = {}) {
   const apiKey = await getApiKey();
   if (!apiKey) throw new Error('API key não configurada. Configure a chave Q10 nas opções da extensão.');
@@ -225,17 +230,25 @@ async function searchContacts({ phone, name }) {
 // ---------- Fetch catalogs ----------
 
 async function fetchCatalogs() {
-  const [programas, periodos, sedes, mediospublicitarios, medioscontacto] = await Promise.all([
-    apiGet('/programas').catch(() => []),
-    apiGet('/periodos').catch(() => []),
-    apiGet('/sedes').catch(() => []),
-    apiGet('/mediospublicitarios', { Estado: true }).catch(() => []),
-    apiGet('/medioscontacto', { Estado: true }).catch(() => [])
+  const [programas, periodos, sedes, jornadas, niveles, tiposIdent, sexos, mediospublicitarios, medioscontacto] = await Promise.all([
+    apiGet('/programas').catch((e) => { console.warn('[Q10] /programas failed:', e.message); return []; }),
+    apiGet('/periodos').catch((e) => { console.warn('[Q10] /periodos failed:', e.message); return []; }),
+    apiGet('/sedes').catch((e) => { console.warn('[Q10] /sedes failed:', e.message); return []; }),
+    apiGet('/jornadas').catch((e) => { console.warn('[Q10] /jornadas failed:', e.message); return []; }),
+    apiGet('/niveles', { Estado: true }).catch((e) => { console.warn('[Q10] /niveles failed:', e.message); return []; }),
+    apiGet('/tiposidentificacion').catch((e) => { console.warn('[Q10] /tiposidentificacion failed:', e.message); return []; }),
+    apiGet('/sexos').catch((e) => { console.warn('[Q10] /sexos failed:', e.message); return []; }),
+    apiGet('/mediospublicitarios', { Estado: true }).catch((e) => { console.warn('[Q10] /mediospublicitarios failed:', e.message); return []; }),
+    apiGet('/medioscontacto', { Estado: true }).catch((e) => { console.warn('[Q10] /medioscontacto failed:', e.message); return []; })
   ]);
   return {
     programas: Array.isArray(programas) ? programas : [],
     periodos: Array.isArray(periodos) ? periodos : [],
     sedes: Array.isArray(sedes) ? sedes : [],
+    jornadas: Array.isArray(jornadas) ? jornadas : [],
+    niveles: Array.isArray(niveles) ? niveles : [],
+    tiposIdentificacion: Array.isArray(tiposIdent) ? tiposIdent : [],
+    sexos: Array.isArray(sexos) ? sexos : [],
     mediospublicitarios: Array.isArray(mediospublicitarios) ? mediospublicitarios : [],
     medioscontacto: Array.isArray(medioscontacto) ? medioscontacto : []
   };
@@ -305,13 +318,35 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       return handle(apiPost('/contactos', msg.body));
 
     case 'createEstudiante':
-      return handle(apiPost('/usuarios', msg.body));
+      // BUG-02 fix: POST /estudiantes (not /usuarios). Schema: Primer_nombre, Primer_apellido,
+      // Codigo_tipo_identificacion, Numero_identificacion, Genero, Email, Celular,
+      // Fecha_nacimiento, Codigo_programa (all required per live API validation).
+      return handle(apiPost('/estudiantes', msg.body));
 
     case 'createInscripcion':
       return handle(apiPost('/inscripciones', msg.body));
 
+    case 'createMatricula':
+      // BUG-04 fix: POST /matriculasProgramas. Schema requires: Consecutivo_inscripcion,
+      // Codigo_estudiante, Fecha_matricula, Consecutivo_sede_jornada, Consecutivo_periodo,
+      // Codigo_nivel, Condicion_matricula (enum — value from Q10 UI), Formalizada (bool).
+      return handle(apiPost('/matriculasProgramas', msg.body));
+
+    case 'createOrdenPago':
+      // BUG-06: /ordenespago returns 400 "La API no aplica para el modelo financiero de la
+      // institución" on tenants without finance module. The sidepanel detects this error
+      // and shows a friendly message instead of crashing.
+      return handle(apiPost('/ordenespago', msg.body));
+
     case 'createOportunidad':
-      return handle(apiPost('/oportunidades', msg.body));
+      return handle((async () => {
+        const body = { ...msg.body };
+        if (!body.Numero_identificacion_asesor) {
+          const asesorId = await getAsesorId();
+          if (asesorId) body.Numero_identificacion_asesor = asesorId;
+        }
+        return apiPost('/oportunidades', body);
+      })());
 
     case 'fetchMedios':
       return handle(Promise.all([
@@ -320,7 +355,23 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       ]).then(([pub, ctc]) => ({ mediospublicitarios: pub, medioscontacto: ctc })));
 
     case 'createActividad':
-      return handle(apiPost('/actividades', msg.body));
+      // BUG-03 fix: POST /actividades expects Consecutivo_negocio, Estado_actividad,
+      // Tipo_actividad, Numero_identificacion_asesor, Fecha_actividad. Asesor ID is
+      // auto-injected from storage if not provided in body.
+      return handle((async () => {
+        const body = { ...msg.body };
+        if (!body.Numero_identificacion_asesor) {
+          const asesorId = await getAsesorId();
+          if (asesorId) body.Numero_identificacion_asesor = asesorId;
+        }
+        if (!body.Fecha_actividad) {
+          body.Fecha_actividad = new Date().toISOString().split('T')[0];
+        }
+        return apiPost('/actividades', body);
+      })());
+
+    case 'getAsesorId':
+      return handle(getAsesorId().then(id => ({ asesorId: id })));
 
     case 'exportAll':
       return handle((async () => {

--- a/options/options.html
+++ b/options/options.html
@@ -257,19 +257,28 @@
     </div>
 
     <div class="card">
-      <div class="card-title">Identificación del asesor</div>
+      <div class="card-title">Asesor (vendedor)</div>
       <div class="card-desc">
-        Número de identificación do vendedor (asesor) logado. Usado automaticamente ao criar
-        oportunidades e registrar atividades no CRM. Obrigatório para o fluxo de vendas.
+        Selecione o vendedor que está usando este plugin. Ele será associado automaticamente
+        a oportunidades e atividades criadas no CRM. A lista vem direto de Q10 → Administrativos.
       </div>
+
+      <div class="status-indicator" id="asesor-status">
+        <div class="status-dot red" id="asesor-dot"></div>
+        <span class="status-label" id="asesor-label">Não configurado</span>
+      </div>
+
       <div class="form-group">
-        <label class="form-label">Numero_identificacion_asesor</label>
-        <input type="text" class="form-input" id="asesor-id-input"
-               placeholder="Ex: 208120496">
-        <div class="form-hint">Busque em Q10 → Administrativos → seu perfil, campo "Número de identificación".</div>
+        <label class="form-label">Asesor</label>
+        <select class="form-input" id="asesor-select" disabled>
+          <option value="">— Configure a API key primeiro —</option>
+        </select>
+        <div class="form-hint">Se faltar alguém, cadastre em Q10 → Administrativos e clique em Atualizar.</div>
       </div>
+
       <div class="btn-row">
-        <button class="btn btn-primary" id="btn-save-asesor" style="flex:1;">💾 Salvar Asesor</button>
+        <button class="btn btn-primary" id="btn-save-asesor" style="flex:1;" disabled>💾 Salvar Asesor</button>
+        <button class="btn btn-danger" id="btn-refresh-asesores" title="Recarregar lista do Q10">🔄</button>
       </div>
     </div>
 

--- a/options/options.html
+++ b/options/options.html
@@ -257,6 +257,23 @@
     </div>
 
     <div class="card">
+      <div class="card-title">Identificación del asesor</div>
+      <div class="card-desc">
+        Número de identificación do vendedor (asesor) logado. Usado automaticamente ao criar
+        oportunidades e registrar atividades no CRM. Obrigatório para o fluxo de vendas.
+      </div>
+      <div class="form-group">
+        <label class="form-label">Numero_identificacion_asesor</label>
+        <input type="text" class="form-input" id="asesor-id-input"
+               placeholder="Ex: 208120496">
+        <div class="form-hint">Busque em Q10 → Administrativos → seu perfil, campo "Número de identificación".</div>
+      </div>
+      <div class="btn-row">
+        <button class="btn btn-primary" id="btn-save-asesor" style="flex:1;">💾 Salvar Asesor</button>
+      </div>
+    </div>
+
+    <div class="card">
       <div class="card-title">Como obter a API Key</div>
       <div class="info-box">
         <strong>📋 Passos:</strong>

--- a/options/options.js
+++ b/options/options.js
@@ -35,41 +35,120 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  // Load current key and asesor ID
-  chrome.storage.sync.get(['q10ApiKey', 'q10AsesorId'], (result) => {
+  // ---------------- Asesor dropdown ----------------
+  const asesorSelect = document.getElementById('asesor-select');
+  const asesorDot = document.getElementById('asesor-dot');
+  const asesorLabel = document.getElementById('asesor-label');
+  const btnSaveAsesor = document.getElementById('btn-save-asesor');
+  const btnRefreshAsesores = document.getElementById('btn-refresh-asesores');
+  let savedAsesorId = null;
+
+  function updateAsesorStatus(configured, name) {
+    if (configured) {
+      asesorDot.className = 'status-dot green';
+      asesorLabel.textContent = name ? `Configurado: ${name}` : 'Configurado ✓';
+    } else {
+      asesorDot.className = 'status-dot red';
+      asesorLabel.textContent = 'Não configurado';
+    }
+  }
+
+  function fullAsesorName(a) {
+    return [a.Primer_nombre, a.Segundo_nombre, a.Primer_apellido, a.Segundo_apellido]
+      .filter(Boolean).map(s => String(s).trim()).filter(Boolean).join(' ');
+  }
+
+  function populateAsesores(list, selectedId) {
+    if (!Array.isArray(list) || list.length === 0) {
+      asesorSelect.innerHTML = '<option value="">— Nenhum administrativo encontrado —</option>';
+      asesorSelect.disabled = true;
+      btnSaveAsesor.disabled = true;
+      return;
+    }
+    const sorted = list.slice().sort((a, b) => fullAsesorName(a).localeCompare(fullAsesorName(b)));
+    const opts = ['<option value="">— Seleccionar asesor —</option>'].concat(
+      sorted.map(a => {
+        const name = fullAsesorName(a) || `Asesor ${a.Numero_identificacion}`;
+        const sel = a.Numero_identificacion === selectedId ? 'selected' : '';
+        return `<option value="${a.Numero_identificacion}" data-name="${name}" ${sel}>${name} (${a.Numero_identificacion})</option>`;
+      })
+    );
+    asesorSelect.innerHTML = opts.join('');
+    asesorSelect.disabled = false;
+    btnSaveAsesor.disabled = false;
+    if (selectedId) {
+      const match = sorted.find(a => a.Numero_identificacion === selectedId);
+      if (match) updateAsesorStatus(true, fullAsesorName(match));
+    }
+  }
+
+  function loadAsesoresList() {
+    chrome.storage.sync.get(['q10ApiKey', 'q10AsesorId'], (result) => {
+      savedAsesorId = result.q10AsesorId || null;
+      if (!result.q10ApiKey) {
+        asesorSelect.innerHTML = '<option value="">— Configure a API key primeiro —</option>';
+        asesorSelect.disabled = true;
+        btnSaveAsesor.disabled = true;
+        updateAsesorStatus(false);
+        return;
+      }
+      asesorSelect.innerHTML = '<option value="">Carregando administrativos...</option>';
+      asesorSelect.disabled = true;
+      chrome.runtime.sendMessage({ action: 'fetchAdministrativos' }, (resp) => {
+        if (!resp || !resp.ok) {
+          const msg = (resp && resp.error) || 'Erro desconhecido';
+          asesorSelect.innerHTML = `<option value="">— Erro: ${msg} —</option>`;
+          asesorSelect.disabled = true;
+          btnSaveAsesor.disabled = true;
+          return;
+        }
+        populateAsesores(resp.data, savedAsesorId);
+      });
+    });
+  }
+
+  // Load on page ready
+  loadAsesoresList();
+
+  btnSaveAsesor.addEventListener('click', () => {
+    const asesorId = asesorSelect.value;
+    if (!asesorId) {
+      showAlert('error', 'Selecione um asesor da lista');
+      return;
+    }
+    const selectedOption = asesorSelect.options[asesorSelect.selectedIndex];
+    const name = selectedOption.getAttribute('data-name') || '';
+    btnSaveAsesor.disabled = true;
+    btnSaveAsesor.textContent = 'Salvando...';
+    chrome.storage.sync.set({ q10AsesorId: asesorId }, () => {
+      if (chrome.runtime.lastError) {
+        showAlert('error', 'Erro ao salvar: ' + chrome.runtime.lastError.message);
+      } else {
+        showAlert('success', `Asesor "${name}" salvo com sucesso!`);
+        savedAsesorId = asesorId;
+        updateAsesorStatus(true, name);
+      }
+      btnSaveAsesor.disabled = false;
+      btnSaveAsesor.textContent = '💾 Salvar Asesor';
+    });
+  });
+
+  btnRefreshAsesores.addEventListener('click', () => {
+    btnRefreshAsesores.disabled = true;
+    // Clear the SW's apiGet cache so we hit the network fresh
+    chrome.runtime.sendMessage({ action: 'clearCache' }, () => {
+      loadAsesoresList();
+      setTimeout(() => { btnRefreshAsesores.disabled = false; }, 800);
+    });
+  });
+
+  // Load API key status (asesor dropdown is handled separately above)
+  chrome.storage.sync.get(['q10ApiKey'], (result) => {
     if (result.q10ApiKey) {
       input.value = result.q10ApiKey;
       updateStatus(true);
     }
-    const asesorInput = document.getElementById('asesor-id-input');
-    if (asesorInput && result.q10AsesorId) {
-      asesorInput.value = result.q10AsesorId;
-    }
   });
-
-  // Save asesor ID (Numero_identificacion_asesor) — required for /oportunidades and /actividades
-  const btnSaveAsesor = document.getElementById('btn-save-asesor');
-  if (btnSaveAsesor) {
-    btnSaveAsesor.addEventListener('click', () => {
-      const asesorInput = document.getElementById('asesor-id-input');
-      const asesorId = (asesorInput.value || '').trim();
-      if (!asesorId) {
-        showAlert('error', 'Informe a identificación del asesor');
-        return;
-      }
-      btnSaveAsesor.disabled = true;
-      btnSaveAsesor.textContent = 'Salvando...';
-      chrome.storage.sync.set({ q10AsesorId: asesorId }, () => {
-        if (chrome.runtime.lastError) {
-          showAlert('error', 'Erro ao salvar: ' + chrome.runtime.lastError.message);
-        } else {
-          showAlert('success', 'Asesor salvo com sucesso!');
-        }
-        btnSaveAsesor.disabled = false;
-        btnSaveAsesor.textContent = '💾 Salvar Asesor';
-      });
-    });
-  }
 
   // Save
   btnSave.addEventListener('click', () => {
@@ -88,6 +167,8 @@ document.addEventListener('DOMContentLoaded', () => {
       } else {
         showAlert('success', 'Configuração salva com sucesso!');
         updateStatus(true);
+        // Auto-load asesores list now that we have an API key
+        chrome.runtime.sendMessage({ action: 'clearCache' }, () => loadAsesoresList());
       }
       btnSave.disabled = false;
       btnSave.textContent = '💾 Salvar';
@@ -101,6 +182,8 @@ document.addEventListener('DOMContentLoaded', () => {
     chrome.storage.sync.remove(['q10ApiKey'], () => {
       input.value = '';
       updateStatus(false);
+      // Reset asesor dropdown since it depends on the key
+      loadAsesoresList();
       showAlert('success', 'API key removida');
     });
   });

--- a/options/options.js
+++ b/options/options.js
@@ -35,13 +35,41 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  // Load current key
-  chrome.storage.sync.get(['q10ApiKey'], (result) => {
+  // Load current key and asesor ID
+  chrome.storage.sync.get(['q10ApiKey', 'q10AsesorId'], (result) => {
     if (result.q10ApiKey) {
       input.value = result.q10ApiKey;
       updateStatus(true);
     }
+    const asesorInput = document.getElementById('asesor-id-input');
+    if (asesorInput && result.q10AsesorId) {
+      asesorInput.value = result.q10AsesorId;
+    }
   });
+
+  // Save asesor ID (Numero_identificacion_asesor) — required for /oportunidades and /actividades
+  const btnSaveAsesor = document.getElementById('btn-save-asesor');
+  if (btnSaveAsesor) {
+    btnSaveAsesor.addEventListener('click', () => {
+      const asesorInput = document.getElementById('asesor-id-input');
+      const asesorId = (asesorInput.value || '').trim();
+      if (!asesorId) {
+        showAlert('error', 'Informe a identificación del asesor');
+        return;
+      }
+      btnSaveAsesor.disabled = true;
+      btnSaveAsesor.textContent = 'Salvando...';
+      chrome.storage.sync.set({ q10AsesorId: asesorId }, () => {
+        if (chrome.runtime.lastError) {
+          showAlert('error', 'Erro ao salvar: ' + chrome.runtime.lastError.message);
+        } else {
+          showAlert('success', 'Asesor salvo com sucesso!');
+        }
+        btnSaveAsesor.disabled = false;
+        btnSaveAsesor.textContent = '💾 Salvar Asesor';
+      });
+    });
+  }
 
   // Save
   btnSave.addEventListener('click', () => {

--- a/options/options.js
+++ b/options/options.js
@@ -58,6 +58,15 @@ document.addEventListener('DOMContentLoaded', () => {
       .filter(Boolean).map(s => String(s).trim()).filter(Boolean).join(' ');
   }
 
+  // Escape API-sourced strings before interpolating into innerHTML templates.
+  // Nomes de administrativos/emails no Q10 são texto livre — sem escape,
+  // caracteres como < " ' podem quebrar o DOM ou abrir XSS.
+  function escHtml(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
   function populateAsesores(list, selectedId) {
     if (!Array.isArray(list) || list.length === 0) {
       asesorSelect.innerHTML = '<option value="">— Nenhum administrativo encontrado —</option>';
@@ -70,7 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
       sorted.map(a => {
         const name = fullAsesorName(a) || `Asesor ${a.Numero_identificacion}`;
         const sel = a.Numero_identificacion === selectedId ? 'selected' : '';
-        return `<option value="${a.Numero_identificacion}" data-name="${name}" ${sel}>${name} (${a.Numero_identificacion})</option>`;
+        return `<option value="${escHtml(a.Numero_identificacion)}" data-name="${escHtml(name)}" ${sel}>${escHtml(name)} (${escHtml(a.Numero_identificacion)})</option>`;
       })
     );
     asesorSelect.innerHTML = opts.join('');
@@ -97,7 +106,7 @@ document.addEventListener('DOMContentLoaded', () => {
       chrome.runtime.sendMessage({ action: 'fetchAdministrativos' }, (resp) => {
         if (!resp || !resp.ok) {
           const msg = (resp && resp.error) || 'Erro desconhecido';
-          asesorSelect.innerHTML = `<option value="">— Erro: ${msg} —</option>`;
+          asesorSelect.innerHTML = `<option value="">— Erro: ${escHtml(msg)} —</option>`;
           asesorSelect.disabled = true;
           btnSaveAsesor.disabled = true;
           return;
@@ -177,14 +186,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Clear
   btnClear.addEventListener('click', () => {
-    if (!confirm('Tem certeza que deseja remover a API key?')) return;
+    if (!confirm('Tem certeza que deseja remover a API key? O asesor configurado também será limpo.')) return;
 
-    chrome.storage.sync.remove(['q10ApiKey'], () => {
+    // Remove q10AsesorId junto: se trocar de tenant/chave, um asesor salvo de outro
+    // tenant seria injetado em oportunidades/atividades pelo service worker.
+    chrome.storage.sync.remove(['q10ApiKey', 'q10AsesorId'], () => {
       input.value = '';
+      savedAsesorId = null;
       updateStatus(false);
-      // Reset asesor dropdown since it depends on the key
+      updateAsesorStatus(false);
       loadAsesoresList();
-      showAlert('success', 'API key removida');
+      showAlert('success', 'API key e asesor removidos');
     });
   });
 

--- a/options/options.js
+++ b/options/options.js
@@ -87,7 +87,19 @@ document.addEventListener('DOMContentLoaded', () => {
     btnSaveAsesor.disabled = false;
     if (selectedId) {
       const match = sorted.find(a => a.Numero_identificacion === selectedId);
-      if (match) updateAsesorStatus(true, fullAsesorName(match));
+      if (match) {
+        updateAsesorStatus(true, fullAsesorName(match));
+      } else {
+        // ID salvo não existe mais nesta lista — pode ser troca de tenant
+        // (user apenas regravou uma key diferente em vez de clicar em Limpar)
+        // ou o administrativo foi removido no Q10. Remover para o SW não
+        // continuar injetando um asesor inexistente em /oportunidades ou /actividades.
+        chrome.storage.sync.remove(['q10AsesorId'], () => {
+          savedAsesorId = null;
+          updateAsesorStatus(false);
+          showAlert('error', 'Asesor anterior no existe en esta lista. Selecione novamente abaixo.');
+        });
+      }
     }
   }
 

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -1485,13 +1485,18 @@
 
   function showCreateActividadModal(contactData) {
     removeModal();
-    // BUG-03 fix: /actividades schema is Consecutivo_negocio, Estado_actividad, Tipo_actividad,
-    // Numero_identificacion_asesor, Fecha_actividad. Previously plugin sent Tipo/Descripcion/
-    // Fecha/Codigo_oportunidad/Observaciones which all 400'd silently.
-    // Valid enum values for Estado_actividad / Tipo_actividad must be copied from Q10 UI — the
-    // API doesn't expose them and brute-force probing (Pendiente/Realizada/Abierta/etc.) all fail.
+    // BUG-03 fix: /actividades schema discovered via live probing (2026-04-20):
+    //   Consecutivo_negocio (int, from existing oportunidad),
+    //   Estado_actividad: "C" = Completada (requires Resultado_actividad)
+    //                     "P" = Programada (requires Descripcion_actividad),
+    //   Tipo_actividad (enum, no API endpoint — values hardcoded from Q10 UI):
+    //     Llamada, WhatsApp, Correo, Nota, Reunión
+    //   Numero_identificacion_asesor (auto-injected by SW from storage),
+    //   Fecha_actividad (auto-set to today by SW if missing).
     const overlay = el('div', 'q10-modal-overlay');
-    const presetNegocio = contactData?.Consecutivo_negocio || '';
+    const presetNegocio = contactData?.Consecutivo_negocio || contactData?.Negocio_favorito?.Consecutivo_negocio || '';
+    const TIPOS_ACTIVIDAD = ['Llamada', 'WhatsApp', 'Correo', 'Nota', 'Reunión'];
+    const tipoOpts = TIPOS_ACTIVIDAD.map(t => `<option value="${t}" ${t === 'WhatsApp' ? 'selected' : ''}>${t}</option>`).join('');
     overlay.innerHTML = `
       <div class="q10-modal">
         <div class="q10-modal-header">
@@ -1500,18 +1505,28 @@
         </div>
         <div class="q10-modal-body">
           <div class="q10-form-group"><label class="q10-form-label">Consecutivo Negocio *</label>
-            <input class="q10-form-input" id="q10-act-negocio" type="number" min="1" value="${presetNegocio}" placeholder="ID del negocio (crear una oportunidad primero)">
-            <div style="font-size:11px;color:#6B7280;margin-top:4px;">Q10 requiere un negocio existente. Cree una oportunidad en el contacto antes de registrar actividades.</div>
-          </div>
-          <div class="q10-form-group"><label class="q10-form-label">Tipo *</label>
-            <input class="q10-form-input" id="q10-act-type" placeholder="Valor exacto del enum Q10 (ej: Llamada)" value="WhatsApp">
-            <div style="font-size:11px;color:#6B7280;margin-top:4px;">Use el valor exacto configurado en Q10. Ejemplo: "Llamada", "Correo electrónico".</div>
+            <input class="q10-form-input" id="q10-act-negocio" type="number" min="1" value="${presetNegocio}" placeholder="ID del negocio (ver oportunidad primero)">
+            <div style="font-size:11px;color:#6B7280;margin-top:4px;">Cree una oportunidad en el contacto antes de registrar actividades; el ID del Primer Negocio aparece en la respuesta.</div>
           </div>
           <div class="q10-form-group"><label class="q10-form-label">Estado *</label>
-            <input class="q10-form-input" id="q10-act-estado" placeholder="Valor exacto del enum (ej: Pendiente)" value="">
-            <div style="font-size:11px;color:#6B7280;margin-top:4px;">Valor exacto del enum Estado_actividad desde Q10.</div>
+            <div style="display:flex;gap:16px;margin-top:4px;">
+              <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:14px;">
+                <input type="radio" name="q10-act-estado" value="C" checked> Completada
+              </label>
+              <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:14px;">
+                <input type="radio" name="q10-act-estado" value="P"> Programada
+              </label>
+            </div>
           </div>
-          <div class="q10-form-group"><label class="q10-form-label">Descripción</label><textarea class="q10-form-textarea" id="q10-act-desc" placeholder="Detalle de la interacción..."></textarea></div>
+          <div class="q10-form-group"><label class="q10-form-label">Tipo *</label>
+            <select class="q10-form-select" id="q10-act-type">${tipoOpts}</select>
+          </div>
+          <div class="q10-form-group" id="q10-act-resultado-wrap"><label class="q10-form-label">Resultado *</label>
+            <textarea class="q10-form-textarea" id="q10-act-resultado" placeholder="Resultado de la interacción (ej: cliente interesado, a pedido agendar presentación)"></textarea>
+          </div>
+          <div class="q10-form-group" id="q10-act-desc-wrap" style="display:none;"><label class="q10-form-label">Descripción *</label>
+            <textarea class="q10-form-textarea" id="q10-act-desc" placeholder="Detalle de la actividad programada"></textarea>
+          </div>
         </div>
         <div class="q10-modal-footer">
           <button class="q10-btn q10-btn-outline q10-modal-cancel">Cancelar</button>
@@ -1523,24 +1538,36 @@
     overlay.querySelector('.q10-modal-close-btn').addEventListener('click', removeModal);
     overlay.querySelector('.q10-modal-cancel').addEventListener('click', removeModal);
 
+    // Toggle Resultado vs Descripción based on Estado (C=Completada, P=Programada)
+    overlay.querySelectorAll('input[name="q10-act-estado"]').forEach(radio => {
+      radio.addEventListener('change', (ev) => {
+        const isCompletada = ev.target.value === 'C';
+        document.getElementById('q10-act-resultado-wrap').style.display = isCompletada ? '' : 'none';
+        document.getElementById('q10-act-desc-wrap').style.display = isCompletada ? 'none' : '';
+      });
+    });
+
     document.getElementById('q10-act-submit').addEventListener('click', async () => {
-      const desc = document.getElementById('q10-act-desc').value.trim();
       const negocio = parseInt(document.getElementById('q10-act-negocio').value, 10);
-      const tipo = document.getElementById('q10-act-type').value.trim();
-      const estado = document.getElementById('q10-act-estado').value.trim();
+      const tipo = document.getElementById('q10-act-type').value;
+      const estado = overlay.querySelector('input[name="q10-act-estado"]:checked').value;
+      const resultado = document.getElementById('q10-act-resultado').value.trim();
+      const desc = document.getElementById('q10-act-desc').value.trim();
       if (!negocio || Number.isNaN(negocio)) { showToast('Consecutivo negocio obligatorio', 'error'); return; }
-      if (!tipo) { showToast('Tipo obligatorio', 'error'); return; }
-      if (!estado) { showToast('Estado obligatorio', 'error'); return; }
+      if (estado === 'C' && !resultado) { showToast('Resultado obligatorio para actividades completadas', 'error'); return; }
+      if (estado === 'P' && !desc) { showToast('Descripción obligatoria para actividades programadas', 'error'); return; }
       const btn = document.getElementById('q10-act-submit');
       btn.disabled = true; btn.textContent = 'Registrando...';
       try {
         // Numero_identificacion_asesor and Fecha_actividad are auto-injected by service-worker.
-        await sendMsg('createActividad', { body: {
+        const body = {
           Consecutivo_negocio: negocio,
           Tipo_actividad: tipo,
-          Estado_actividad: estado,
-          Descripcion: desc || `Interacción WhatsApp con ${fullName(contactData)}`,
-        }});
+          Estado_actividad: estado, // "C" or "P"
+        };
+        if (estado === 'C') body.Resultado_actividad = resultado;
+        else body.Descripcion_actividad = desc;
+        await sendMsg('createActividad', { body });
         showToast('Actividad registrada ✓', 'success');
         removeModal();
       } catch (err) {

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -834,7 +834,18 @@
         `;
         break;
 
-      case 1:
+      case 1: {
+        // BUG-02 fix: use real /tiposidentificacion, /sexos and /programas codes
+        // (previously hardcoded values like "CC", "Masculino" did not match Q10 tenant config).
+        const doctypeOpts = (catalogsCache?.tiposIdentificacion || [])
+          .map(t => `<option value="${t.Codigo}">${t.Nombre} (${t.Abreviatura || t.Codigo})</option>`)
+          .join('');
+        const genderOpts = (catalogsCache?.sexos || [])
+          .map(s => `<option value="${s.Codigo_sexo}">${s.Nombre_sexo}</option>`)
+          .join('');
+        const progOptsCase1 = (catalogsCache?.programas || [])
+          .map(p => `<option value="${p.Codigo}">${p.Nombre || p.Codigo}</option>`)
+          .join('');
         formHtml = `
           <div class="q10-wizard-step-header">
             ${icon('userPlus','q10-wizard-step-icon')}
@@ -846,26 +857,41 @@
           <div class="q10-info-card" style="margin-bottom:16px;background:#F0FDF4;border-color:#BBF7D0;">
             <div style="font-size:12px;color:#065F46;">✅ Contacto creado: <strong>${fullName(res.contacto)}</strong></div>
           </div>
-          <div class="q10-form-group"><label class="q10-form-label">Tipo de Identificación</label>
+          <div class="q10-form-group"><label class="q10-form-label">Tipo de Identificación *</label>
             <select class="q10-form-select" id="wz-doctype">
-              <option value="CC">Cédula de Ciudadanía</option><option value="CE">Cédula de Extranjería</option>
-              <option value="TI">Tarjeta de Identidad</option><option value="PA">Pasaporte</option>
-              <option value="CPF">CPF</option><option value="Otro">Otro</option>
+              <option value="">— Seleccionar —</option>${doctypeOpts || '<option value="" disabled>No hay tipos disponibles</option>'}
             </select>
           </div>
-          <div class="q10-form-group"><label class="q10-form-label">Fecha de Nacimiento</label><input class="q10-form-input" id="wz-birthdate" type="date"></div>
-          <div class="q10-form-group"><label class="q10-form-label">Género</label>
-            <select class="q10-form-select" id="wz-gender"><option value="Masculino">Masculino</option><option value="Femenino">Femenino</option><option value="Otro">Otro</option></select>
+          <div class="q10-form-group"><label class="q10-form-label">Fecha de Nacimiento *</label><input class="q10-form-input" id="wz-birthdate" type="date" required></div>
+          <div class="q10-form-group"><label class="q10-form-label">Género *</label>
+            <select class="q10-form-select" id="wz-gender">
+              <option value="">— Seleccionar —</option>${genderOpts || '<option value="" disabled>No hay datos</option>'}
+            </select>
           </div>
-          <div class="q10-form-group"><label class="q10-form-label">Dirección</label><input class="q10-form-input" id="wz-address" placeholder="Dirección completa"></div>
+          <div class="q10-form-group"><label class="q10-form-label">Programa *</label>
+            <select class="q10-form-select" id="wz-programa-init">
+              <option value="">— Seleccionar programa —</option>${progOptsCase1 || '<option value="" disabled>No hay programas</option>'}
+            </select>
+          </div>
           <div class="q10-form-group"><label class="q10-form-label">Observaciones</label><textarea class="q10-form-textarea" id="wz-est-obs" placeholder="Notas adicionales..."></textarea></div>
         `;
         break;
+      }
 
       case 2:
         {
-          const programasOpts = (catalogsCache?.programas || []).map(p => `<option value="${p.Codigo}">${p.Nombre || p.Descripcion || p.Codigo}</option>`).join('');
-          const periodosOpts = (catalogsCache?.periodos || []).map(p => `<option value="${p.Codigo}">${p.Nombre || p.Descripcion || p.Codigo}</option>`).join('');
+          // BUG-05 fix: /periodos returns `Consecutivo` (int), not `Codigo`. Use correct field.
+          // Pre-selects programa that was chosen in Case 1.
+          const preselectedProg = res.estudiante?.Codigo_programa_inicial;
+          const programasOpts = (catalogsCache?.programas || [])
+            .map(p => `<option value="${p.Codigo}" ${p.Codigo === preselectedProg ? 'selected' : ''}>${p.Nombre || p.Codigo}</option>`)
+            .join('');
+          const periodosOpts = (catalogsCache?.periodos || [])
+            .map(p => `<option value="${p.Consecutivo}">${p.Nombre || p.Consecutivo}</option>`)
+            .join('');
+          const jornadaOpts = (catalogsCache?.jornadas || [])
+            .map(j => `<option value="${j.Codigo}">${j.Nombre}</option>`)
+            .join('');
           formHtml = `
             <div class="q10-wizard-step-header">
               ${icon('book','q10-wizard-step-icon')}
@@ -884,7 +910,7 @@
               <select class="q10-form-select" id="wz-periodo"><option value="">— Seleccionar periodo —</option>${periodosOpts || '<option value="" disabled>No hay periodos</option>'}</select>
             </div>
             <div class="q10-form-group"><label class="q10-form-label">Jornada</label>
-              <select class="q10-form-select" id="wz-jornada"><option value="Diurna">Diurna</option><option value="Nocturna">Nocturna</option><option value="Sabatina">Sabatina</option><option value="Virtual">Virtual</option></select>
+              <select class="q10-form-select" id="wz-jornada"><option value="">— Seleccionar jornada —</option>${jornadaOpts || '<option value="" disabled>No hay jornadas</option>'}</select>
             </div>
             <div class="q10-form-group"><label class="q10-form-label">Observaciones</label><textarea class="q10-form-textarea" id="wz-insc-obs" placeholder="Notas..."></textarea></div>
           `;
@@ -893,8 +919,16 @@
 
       case 3:
         {
+          // BUG-04 fix: /matriculasProgramas schema requires Consecutivo_inscripcion,
+          // Codigo_estudiante, Fecha_matricula, Consecutivo_sede_jornada, Consecutivo_periodo,
+          // Codigo_nivel, Condicion_matricula, Formalizada. Previously plugin sent wrong fields
+          // to a non-existent `createMatricula` handler.
           const progName = catalogsCache?.programas?.find(p => p.Codigo === res.inscripcion?.Codigo_programa)?.Nombre || res.inscripcion?.Codigo_programa || '—';
-          const perName = catalogsCache?.periodos?.find(p => p.Codigo === res.inscripcion?.Codigo_periodo)?.Nombre || res.inscripcion?.Codigo_periodo || '—';
+          const perName = catalogsCache?.periodos?.find(p => p.Consecutivo === res.inscripcion?.Consecutivo_periodo)?.Nombre || res.inscripcion?.Consecutivo_periodo || '—';
+          const nivelOpts = (catalogsCache?.niveles || [])
+            .map(n => `<option value="${n.Codigo_nivel}">${n.Nombre_nivel}</option>`)
+            .join('');
+          const todayIso = new Date().toISOString().split('T')[0];
           formHtml = `
             <div class="q10-wizard-step-header">
               ${icon('graduation','q10-wizard-step-icon')}
@@ -907,17 +941,32 @@
               <div style="font-size:12px;color:#065F46;">✅ Inscripción realizada</div>
             </div>
             <div class="q10-section">
-              <div class="q10-section-title">Resumen de Matrícula</div>
+              <div class="q10-section-title">Resumen</div>
               <div class="q10-info-card">
                 <div class="q10-info-row"><span class="q10-info-label">Alumno</span><span class="q10-info-value">${fullName(res.contacto)}</span></div>
                 <div class="q10-info-row"><span class="q10-info-label">Programa</span><span class="q10-info-value">${progName}</span></div>
                 <div class="q10-info-row"><span class="q10-info-label">Periodo</span><span class="q10-info-value">${perName}</span></div>
               </div>
             </div>
-            <div class="q10-form-group"><label class="q10-form-label">Estado de Matrícula</label>
-              <select class="q10-form-select" id="wz-mat-estado"><option value="Activo">Activo</option><option value="Provisional">Provisional</option></select>
+            <div class="q10-form-group"><label class="q10-form-label">Nivel *</label>
+              <select class="q10-form-select" id="wz-mat-nivel">
+                <option value="">— Seleccionar nivel —</option>${nivelOpts || '<option value="" disabled>No hay niveles</option>'}
+              </select>
             </div>
-            <div class="q10-form-group"><label class="q10-form-label">Observaciones</label><textarea class="q10-form-textarea" id="wz-mat-obs" placeholder="Notas..."></textarea></div>
+            <div class="q10-form-group"><label class="q10-form-label">Fecha de Matrícula *</label><input class="q10-form-input" id="wz-mat-fecha" type="date" value="${todayIso}" required></div>
+            <div class="q10-form-group"><label class="q10-form-label">Consecutivo Sede-Jornada *</label>
+              <input class="q10-form-input" id="wz-mat-sedejornada" type="number" min="1" placeholder="Ej: 1 (consulte en Q10)" value="1">
+              <div style="font-size:11px;color:#6B7280;margin-top:4px;">ID del registro sede-jornada en Q10. Consulte /cursos → Consecutivo_sede_jornada.</div>
+            </div>
+            <div class="q10-form-group"><label class="q10-form-label">Condición de Matrícula *</label>
+              <input class="q10-form-input" id="wz-mat-condicion" placeholder="Valor exacto desde Q10 UI">
+              <div style="font-size:11px;color:#6B7280;margin-top:4px;">Enum Q10 (ej.: "Nuevo"/"Antiguo"). Valor exato vindo da UI Q10.</div>
+            </div>
+            <div class="q10-form-group">
+              <label style="display:flex;align-items:center;gap:8px;font-size:14px;color:#111;cursor:pointer;">
+                <input type="checkbox" id="wz-mat-formalizada" checked> Formalizada
+              </label>
+            </div>
           `;
         }
         break;
@@ -989,7 +1038,10 @@
       switch (step) {
         case 0: {
           const fname = document.getElementById('wz-fname').value.trim();
+          const fname2 = document.getElementById('wz-fname2').value.trim();
           const lname = document.getElementById('wz-lname').value.trim();
+          const lname2 = document.getElementById('wz-lname2').value.trim();
+          const wzDocnum = document.getElementById('wz-docnum').value.trim();
           if (!fname || !lname) throw new Error('Nombre y apellido son obligatorios.');
           const wzEmail = document.getElementById('wz-email').value.trim();
           const wzCelular = document.getElementById('wz-phone').value.trim();
@@ -999,40 +1051,71 @@
           if (wzCelular) wzDetalle.push({ Tipo_detalle: 'Telefono', Descripcion: wzCelular });
           const payload = {
             Consecutivo_oportunidad: 0,
-            Nombres: [fname, document.getElementById('wz-fname2').value.trim()].filter(Boolean).join(' '),
-            Apellidos: [lname, document.getElementById('wz-lname2').value.trim()].filter(Boolean).join(' '),
+            Nombres: [fname, fname2].filter(Boolean).join(' '),
+            Apellidos: [lname, lname2].filter(Boolean).join(' '),
             Detalle: wzDetalle,
           };
           const result = await sendMsg('createContacto', { body: payload });
-          res.contacto = { ...payload, ...result };
+          // Merge API response with payload and individual fields for later wizard steps.
+          // /estudiantes needs Primer_nombre/Primer_apellido separately (BUG-02).
+          res.contacto = {
+            ...payload,
+            ...result,
+            Primer_nombre: fname,
+            Segundo_nombre: fname2 || null,
+            Primer_apellido: lname,
+            Segundo_apellido: lname2 || null,
+            Email: wzEmail,
+            Celular: wzCelular,
+            Numero_identificacion: wzDocnum,
+          };
           showToast('Contacto creado ✓', 'success');
           break;
         }
         case 1: {
+          // BUG-02 fix: POST /estudiantes schema requires these exact fields (validated live):
+          // Primer_nombre, Primer_apellido, Codigo_tipo_identificacion, Numero_identificacion,
+          // Genero, Email, Celular, Fecha_nacimiento, Codigo_programa.
+          // Previously plugin sent `Tipo_identificacion` (wrong name) and posted to /usuarios.
+          const doctype = document.getElementById('wz-doctype').value;
+          const birthdate = document.getElementById('wz-birthdate').value;
+          const gender = document.getElementById('wz-gender').value;
+          const programa = document.getElementById('wz-programa-init').value;
+          if (!doctype) throw new Error('Tipo de Identificación es obligatorio.');
+          if (!birthdate) throw new Error('Fecha de nacimiento es obligatoria.');
+          if (!gender) throw new Error('Género es obligatorio.');
+          if (!programa) throw new Error('Programa es obligatorio.');
+          if (!res.contacto.Numero_identificacion) throw new Error('Número de identificación no fue ingresado en el paso anterior.');
           const payload = {
-            Codigo_contacto: res.contacto.Codigo,
-            Primer_nombre: res.contacto.Primer_nombre, Segundo_nombre: res.contacto.Segundo_nombre,
-            Primer_apellido: res.contacto.Primer_apellido, Segundo_apellido: res.contacto.Segundo_apellido,
+            Primer_nombre: res.contacto.Primer_nombre,
+            Primer_apellido: res.contacto.Primer_apellido,
+            Codigo_tipo_identificacion: doctype,
             Numero_identificacion: res.contacto.Numero_identificacion,
-            Tipo_identificacion: document.getElementById('wz-doctype').value,
-            Email: res.contacto.Email, Celular: res.contacto.Celular,
-            Fecha_nacimiento: document.getElementById('wz-birthdate').value || null,
-            Genero: document.getElementById('wz-gender').value,
-            Direccion: document.getElementById('wz-address').value.trim(),
-            Observaciones: document.getElementById('wz-est-obs').value.trim(),
+            Genero: gender,
+            Email: res.contacto.Email,
+            Celular: res.contacto.Celular,
+            Fecha_nacimiento: birthdate,
+            Codigo_programa: programa,
           };
           const result = await sendMsg('createEstudiante', { body: payload });
-          res.estudiante = { ...payload, ...result };
+          // Track programa selection in wizardState so later steps can default to it.
+          res.estudiante = { ...payload, ...result, Codigo_programa_inicial: programa };
           showToast('Estudiante registrado ✓', 'success');
           break;
         }
         case 2: {
+          // BUG-05 fix: /periodos returns Consecutivo (number). API expects Consecutivo_periodo,
+          // not Codigo_periodo (which was silently ignored before).
           const programa = document.getElementById('wz-programa').value;
           const periodo = document.getElementById('wz-periodo').value;
           if (!programa || !periodo) throw new Error('Seleccione programa y periodo.');
+          const codigoEstudiante = res.estudiante.Codigo_estudiante || res.estudiante.Codigo;
+          if (!codigoEstudiante) throw new Error('Código del estudiante no disponible. Vuelva al paso anterior.');
           const payload = {
-            Codigo_estudiante: res.estudiante.Codigo, Codigo_programa: programa,
-            Codigo_periodo: periodo, Jornada: document.getElementById('wz-jornada').value,
+            Codigo_estudiante: codigoEstudiante,
+            Codigo_programa: programa,
+            Consecutivo_periodo: parseInt(periodo, 10),
+            Codigo_jornada: document.getElementById('wz-jornada').value || null,
             Observaciones: document.getElementById('wz-insc-obs').value.trim(),
           };
           const result = await sendMsg('createInscripcion', { body: payload });
@@ -1041,12 +1124,28 @@
           break;
         }
         case 3: {
+          // BUG-04 fix: /matriculasProgramas requires 8 fields (validated live 2026-04-20).
+          const nivel = document.getElementById('wz-mat-nivel').value;
+          const fecha = document.getElementById('wz-mat-fecha').value;
+          const sedeJornada = parseInt(document.getElementById('wz-mat-sedejornada').value, 10);
+          const condicion = document.getElementById('wz-mat-condicion').value.trim();
+          const formalizada = document.getElementById('wz-mat-formalizada').checked;
+          if (!nivel) throw new Error('Seleccione el nivel.');
+          if (!fecha) throw new Error('Fecha de matrícula es obligatoria.');
+          if (!sedeJornada || Number.isNaN(sedeJornada)) throw new Error('Consecutivo sede-jornada es obligatorio.');
+          if (!condicion) throw new Error('Condición de matrícula es obligatoria (valor Q10 exacto).');
+          if (!res.inscripcion?.Consecutivo_inscripcion) throw new Error('Consecutivo de inscripción no disponible del paso anterior.');
+          const codigoEstudiante = res.estudiante.Codigo_estudiante || res.estudiante.Codigo;
+          if (!codigoEstudiante) throw new Error('Código del estudiante no disponible.');
           const payload = {
-            Codigo_estudiante: res.estudiante.Codigo,
-            Codigo_programa: res.inscripcion.Codigo_programa,
-            Codigo_periodo: res.inscripcion.Codigo_periodo,
-            Estado: document.getElementById('wz-mat-estado').value,
-            Observaciones: document.getElementById('wz-mat-obs').value.trim(),
+            Consecutivo_inscripcion: res.inscripcion.Consecutivo_inscripcion,
+            Codigo_estudiante: codigoEstudiante,
+            Fecha_matricula: fecha,
+            Consecutivo_sede_jornada: sedeJornada,
+            Consecutivo_periodo: res.inscripcion.Consecutivo_periodo,
+            Codigo_nivel: nivel,
+            Condicion_matricula: condicion,
+            Formalizada: formalizada,
           };
           const result = await sendMsg('createMatricula', { body: payload });
           res.matricula = { ...payload, ...result };
@@ -1054,18 +1153,33 @@
           break;
         }
         case 4: {
+          // BUG-06: /ordenespago requires modelo financiero activo on the Q10 tenant.
+          // If not available (e.g. geniusidiomas tenant), show friendly message instead of error.
           const concepto = document.getElementById('wz-cobro-concepto').value.trim();
           const valor = document.getElementById('wz-cobro-valor').value;
           const fecha = document.getElementById('wz-cobro-fecha').value;
           if (!concepto || !valor || !fecha) throw new Error('Concepto, valor y fecha son obligatorios.');
+          const codigoEstudiante = res.estudiante.Codigo_estudiante || res.estudiante.Codigo;
           const payload = {
-            Codigo_estudiante: res.estudiante.Codigo, Concepto: concepto,
-            Valor: parseFloat(valor), Fecha_vencimiento: fecha,
+            Codigo_estudiante: codigoEstudiante,
+            Concepto: concepto,
+            Valor: parseFloat(valor),
+            Fecha_vencimiento: fecha,
             Observaciones: document.getElementById('wz-cobro-obs').value.trim(),
           };
-          const result = await sendMsg('createOrdenPago', { body: payload });
-          res.cobro = { ...payload, ...result };
-          showToast('Orden de pago generada ✓', 'success');
+          try {
+            const result = await sendMsg('createOrdenPago', { body: payload });
+            res.cobro = { ...payload, ...result };
+            showToast('Orden de pago generada ✓', 'success');
+          } catch (e) {
+            if (e && e.message && /modelo financiero/i.test(e.message)) {
+              // Tenant sem modelo financeiro configurado — completa matrícula sem cobro.
+              res.cobro = { skipped: true, reason: 'modelo_financiero_ausente' };
+              showToast('Cobro no disponible: esta institución no tiene modelo financiero Q10. Matrícula completada sin orden de pago.', 'info');
+            } else {
+              throw e;
+            }
+          }
           renderWizardComplete();
           return;
         }
@@ -1363,7 +1477,13 @@
 
   function showCreateActividadModal(contactData) {
     removeModal();
+    // BUG-03 fix: /actividades schema is Consecutivo_negocio, Estado_actividad, Tipo_actividad,
+    // Numero_identificacion_asesor, Fecha_actividad. Previously plugin sent Tipo/Descripcion/
+    // Fecha/Codigo_oportunidad/Observaciones which all 400'd silently.
+    // Valid enum values for Estado_actividad / Tipo_actividad must be copied from Q10 UI — the
+    // API doesn't expose them and brute-force probing (Pendiente/Realizada/Abierta/etc.) all fail.
     const overlay = el('div', 'q10-modal-overlay');
+    const presetNegocio = contactData?.Consecutivo_negocio || '';
     overlay.innerHTML = `
       <div class="q10-modal">
         <div class="q10-modal-header">
@@ -1371,13 +1491,19 @@
           <button class="q10-modal-close-btn">${ICONS.close}</button>
         </div>
         <div class="q10-modal-body">
-          <div class="q10-form-group"><label class="q10-form-label">Tipo *</label>
-            <select class="q10-form-select" id="q10-act-type">
-              <option value="Llamada">Llamada</option><option value="WhatsApp" selected>WhatsApp</option>
-              <option value="Email">Email</option><option value="Reunión">Reunión</option><option value="Otro">Otro</option>
-            </select>
+          <div class="q10-form-group"><label class="q10-form-label">Consecutivo Negocio *</label>
+            <input class="q10-form-input" id="q10-act-negocio" type="number" min="1" value="${presetNegocio}" placeholder="ID del negocio (crear una oportunidad primero)">
+            <div style="font-size:11px;color:#6B7280;margin-top:4px;">Q10 requiere un negocio existente. Cree una oportunidad en el contacto antes de registrar actividades.</div>
           </div>
-          <div class="q10-form-group"><label class="q10-form-label">Descripción *</label><textarea class="q10-form-textarea" id="q10-act-desc" placeholder="Detalle de la interacción..."></textarea></div>
+          <div class="q10-form-group"><label class="q10-form-label">Tipo *</label>
+            <input class="q10-form-input" id="q10-act-type" placeholder="Valor exacto del enum Q10 (ej: Llamada)" value="WhatsApp">
+            <div style="font-size:11px;color:#6B7280;margin-top:4px;">Use el valor exacto configurado en Q10. Ejemplo: "Llamada", "Correo electrónico".</div>
+          </div>
+          <div class="q10-form-group"><label class="q10-form-label">Estado *</label>
+            <input class="q10-form-input" id="q10-act-estado" placeholder="Valor exacto del enum (ej: Pendiente)" value="">
+            <div style="font-size:11px;color:#6B7280;margin-top:4px;">Valor exacto del enum Estado_actividad desde Q10.</div>
+          </div>
+          <div class="q10-form-group"><label class="q10-form-label">Descripción</label><textarea class="q10-form-textarea" id="q10-act-desc" placeholder="Detalle de la interacción..."></textarea></div>
         </div>
         <div class="q10-modal-footer">
           <button class="q10-btn q10-btn-outline q10-modal-cancel">Cancelar</button>
@@ -1391,11 +1517,22 @@
 
     document.getElementById('q10-act-submit').addEventListener('click', async () => {
       const desc = document.getElementById('q10-act-desc').value.trim();
-      if (!desc) { showToast('Descripción obligatoria', 'error'); return; }
+      const negocio = parseInt(document.getElementById('q10-act-negocio').value, 10);
+      const tipo = document.getElementById('q10-act-type').value.trim();
+      const estado = document.getElementById('q10-act-estado').value.trim();
+      if (!negocio || Number.isNaN(negocio)) { showToast('Consecutivo negocio obligatorio', 'error'); return; }
+      if (!tipo) { showToast('Tipo obligatorio', 'error'); return; }
+      if (!estado) { showToast('Estado obligatorio', 'error'); return; }
       const btn = document.getElementById('q10-act-submit');
       btn.disabled = true; btn.textContent = 'Registrando...';
       try {
-        await sendMsg('createActividad', { body: { Tipo: document.getElementById('q10-act-type').value, Descripcion: desc, Fecha: new Date().toISOString(), Codigo_oportunidad: contactData?.Codigo || null, Observaciones: `Contacto: ${fullName(contactData)} | WhatsApp` } });
+        // Numero_identificacion_asesor and Fecha_actividad are auto-injected by service-worker.
+        await sendMsg('createActividad', { body: {
+          Consecutivo_negocio: negocio,
+          Tipo_actividad: tipo,
+          Estado_actividad: estado,
+          Descripcion: desc || `Interacción WhatsApp con ${fullName(contactData)}`,
+        }});
         showToast('Actividad registrada ✓', 'success');
         removeModal();
       } catch (err) {

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -66,6 +66,18 @@
       .filter(Boolean).join(' ');
   }
 
+  // Escape API-sourced strings before interpolating into innerHTML templates.
+  // Q10 catálogos (administrativos, programas, etc.) trazem nomes configurados pelo
+  // cliente — sem escape, um nome com `<` / `"` quebra o DOM ou abre XSS.
+  function escHtml(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
   function showToast(text, type = '') {
     const existing = document.querySelector('.q10-toast');
     if (existing) existing.remove();
@@ -828,7 +840,7 @@
           <div class="q10-form-group"><label class="q10-form-label">Segundo Nombre</label><input class="q10-form-input" id="wz-fname2" value="${pf.Segundo_nombre||''}" placeholder="Segundo nombre"></div>
           <div class="q10-form-group"><label class="q10-form-label">Primer Apellido *</label><input class="q10-form-input" id="wz-lname" value="${pf.Primer_apellido||''}" placeholder="Apellido"></div>
           <div class="q10-form-group"><label class="q10-form-label">Segundo Apellido</label><input class="q10-form-input" id="wz-lname2" value="${pf.Segundo_apellido||''}" placeholder="Segundo apellido"></div>
-          <div class="q10-form-group"><label class="q10-form-label">Número de Identificación</label><input class="q10-form-input" id="wz-docnum" value="${pf.Numero_identificacion||''}" placeholder="CPF / Cédula / Pasaporte"></div>
+          <div class="q10-form-group"><label class="q10-form-label">Número de Identificación *</label><input class="q10-form-input" id="wz-docnum" value="${pf.Numero_identificacion||''}" placeholder="CPF / Cédula / Pasaporte"></div>
           <div class="q10-form-group"><label class="q10-form-label">Email</label><input class="q10-form-input" id="wz-email" type="email" value="${pf.Email||''}" placeholder="email@ejemplo.com"></div>
           <div class="q10-form-group"><label class="q10-form-label">Celular</label><input class="q10-form-input" id="wz-phone" value="${wizardState.phone||''}" placeholder="+502 4512-3489"></div>
         `;
@@ -838,13 +850,13 @@
         // BUG-02 fix: use real /tiposidentificacion, /sexos and /programas codes
         // (previously hardcoded values like "CC", "Masculino" did not match Q10 tenant config).
         const doctypeOpts = (catalogsCache?.tiposIdentificacion || [])
-          .map(t => `<option value="${t.Codigo}">${t.Nombre} (${t.Abreviatura || t.Codigo})</option>`)
+          .map(t => `<option value="${escHtml(t.Codigo)}">${escHtml(t.Nombre)} (${escHtml(t.Abreviatura || t.Codigo)})</option>`)
           .join('');
         const genderOpts = (catalogsCache?.sexos || [])
-          .map(s => `<option value="${s.Codigo_sexo}">${s.Nombre_sexo}</option>`)
+          .map(s => `<option value="${escHtml(s.Codigo_sexo)}">${escHtml(s.Nombre_sexo)}</option>`)
           .join('');
         const progOptsCase1 = (catalogsCache?.programas || [])
-          .map(p => `<option value="${p.Codigo}">${p.Nombre || p.Codigo}</option>`)
+          .map(p => `<option value="${escHtml(p.Codigo)}">${escHtml(p.Nombre || p.Codigo)}</option>`)
           .join('');
         formHtml = `
           <div class="q10-wizard-step-header">
@@ -884,13 +896,13 @@
           // Pre-selects programa that was chosen in Case 1.
           const preselectedProg = res.estudiante?.Codigo_programa_inicial;
           const programasOpts = (catalogsCache?.programas || [])
-            .map(p => `<option value="${p.Codigo}" ${p.Codigo === preselectedProg ? 'selected' : ''}>${p.Nombre || p.Codigo}</option>`)
+            .map(p => `<option value="${escHtml(p.Codigo)}" ${p.Codigo === preselectedProg ? 'selected' : ''}>${escHtml(p.Nombre || p.Codigo)}</option>`)
             .join('');
           const periodosOpts = (catalogsCache?.periodos || [])
-            .map(p => `<option value="${p.Consecutivo}">${p.Nombre || p.Consecutivo}</option>`)
+            .map(p => `<option value="${escHtml(p.Consecutivo)}">${escHtml(p.Nombre || p.Consecutivo)}</option>`)
             .join('');
           const jornadaOpts = (catalogsCache?.jornadas || [])
-            .map(j => `<option value="${j.Codigo}">${j.Nombre}</option>`)
+            .map(j => `<option value="${escHtml(j.Codigo)}">${escHtml(j.Nombre)}</option>`)
             .join('');
           formHtml = `
             <div class="q10-wizard-step-header">
@@ -926,13 +938,13 @@
           const progName = catalogsCache?.programas?.find(p => p.Codigo === res.inscripcion?.Codigo_programa)?.Nombre || res.inscripcion?.Codigo_programa || '—';
           const perName = catalogsCache?.periodos?.find(p => p.Consecutivo === res.inscripcion?.Consecutivo_periodo)?.Nombre || res.inscripcion?.Consecutivo_periodo || '—';
           const nivelOpts = (catalogsCache?.niveles || [])
-            .map(n => `<option value="${n.Codigo_nivel}">${n.Nombre_nivel}</option>`)
+            .map(n => `<option value="${escHtml(n.Codigo_nivel)}">${escHtml(n.Nombre_nivel)}</option>`)
             .join('');
           const sedejornadaOpts = (catalogsCache?.sedesjornadas || [])
-            .map(sj => `<option value="${sj.Consecutivo}">${sj.Sede_jornada || (sj.Nombre_sede + ' - ' + sj.Nombre_jornada)}</option>`)
+            .map(sj => `<option value="${escHtml(sj.Consecutivo)}">${escHtml(sj.Sede_jornada || ((sj.Nombre_sede || '') + ' - ' + (sj.Nombre_jornada || '')))}</option>`)
             .join('');
           const condicionOpts = (catalogsCache?.condicionesMatricula || [])
-            .map(c => `<option value="${c.Codigo}">${c.Nombre}</option>`)
+            .map(c => `<option value="${escHtml(c.Codigo)}">${escHtml(c.Nombre)}</option>`)
             .join('');
           const todayIso = new Date().toISOString().split('T')[0];
           formHtml = `
@@ -1052,11 +1064,17 @@
           const wzDocnum = document.getElementById('wz-docnum').value.trim();
           if (!fname || !lname) throw new Error('Nombre y apellido son obligatorios.');
           const wzEmail = document.getElementById('wz-email').value.trim();
-          const wzCelular = document.getElementById('wz-phone').value.trim();
-          if (!wzEmail && !wzCelular) throw new Error('Informe email ou celular (ao menos um).');
+          const wzCelularRaw = document.getElementById('wz-phone').value.trim();
+          if (!wzEmail && !wzCelularRaw) throw new Error('Informe email ou celular (ao menos um).');
+          // Fail fast: Número de Identificación is required later (Case 1 POST /estudiantes).
+          // Don't create a contact in Q10 the user cannot use later.
+          if (!wzDocnum) throw new Error('Número de Identificación es obligatorio para avanzar al registro de estudiante.');
+          // Q10 Detalle[] only accepts Tipo_detalle="Celular" or "Email"; Celular is capped at 12 digits.
+          // Mirror the logic from the standalone contacto modal (line ~1463).
+          const wzCelularQ10 = wzCelularRaw.replace(/\D/g, '').slice(-12);
           const wzDetalle = [];
           if (wzEmail) wzDetalle.push({ Tipo_detalle: 'Email', Descripcion: wzEmail });
-          if (wzCelular) wzDetalle.push({ Tipo_detalle: 'Telefono', Descripcion: wzCelular });
+          if (wzCelularQ10) wzDetalle.push({ Tipo_detalle: 'Celular', Descripcion: wzCelularQ10 });
           const payload = {
             Consecutivo_oportunidad: 0,
             Nombres: [fname, fname2].filter(Boolean).join(' '),
@@ -1074,7 +1092,7 @@
             Primer_apellido: lname,
             Segundo_apellido: lname2 || null,
             Email: wzEmail,
-            Celular: wzCelular,
+            Celular: wzCelularQ10,
             Numero_identificacion: wzDocnum,
           };
           showToast('Contacto creado ✓', 'success');
@@ -1351,12 +1369,12 @@
 
       pubSel.innerHTML = '<option value="">— Como conheceu? —</option>' +
         (data.mediospublicitarios || []).map(m =>
-          `<option value="${m.Consecutivo}">${m.Nombre || m.Descripcion || m.Consecutivo}</option>`
+          `<option value="${escHtml(m.Consecutivo)}">${escHtml(m.Nombre || m.Descripcion || m.Consecutivo)}</option>`
         ).join('');
 
       ctcSel.innerHTML = '<option value="">— Canal —</option>' +
         (data.medioscontacto || []).map(m =>
-          `<option value="${m.Consecutivo}">${m.Nombre || m.Descripcion || m.Consecutivo}</option>`
+          `<option value="${escHtml(m.Consecutivo)}">${escHtml(m.Nombre || m.Descripcion || m.Consecutivo)}</option>`
         ).join('');
 
       // Auto-select WhatsApp if found

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -928,6 +928,12 @@
           const nivelOpts = (catalogsCache?.niveles || [])
             .map(n => `<option value="${n.Codigo_nivel}">${n.Nombre_nivel}</option>`)
             .join('');
+          const sedejornadaOpts = (catalogsCache?.sedesjornadas || [])
+            .map(sj => `<option value="${sj.Consecutivo}">${sj.Sede_jornada || (sj.Nombre_sede + ' - ' + sj.Nombre_jornada)}</option>`)
+            .join('');
+          const condicionOpts = (catalogsCache?.condicionesMatricula || [])
+            .map(c => `<option value="${c.Codigo}">${c.Nombre}</option>`)
+            .join('');
           const todayIso = new Date().toISOString().split('T')[0];
           formHtml = `
             <div class="q10-wizard-step-header">
@@ -954,13 +960,15 @@
               </select>
             </div>
             <div class="q10-form-group"><label class="q10-form-label">Fecha de Matrícula *</label><input class="q10-form-input" id="wz-mat-fecha" type="date" value="${todayIso}" required></div>
-            <div class="q10-form-group"><label class="q10-form-label">Consecutivo Sede-Jornada *</label>
-              <input class="q10-form-input" id="wz-mat-sedejornada" type="number" min="1" placeholder="Ej: 1 (consulte en Q10)" value="1">
-              <div style="font-size:11px;color:#6B7280;margin-top:4px;">ID del registro sede-jornada en Q10. Consulte /cursos → Consecutivo_sede_jornada.</div>
+            <div class="q10-form-group"><label class="q10-form-label">Sede-Jornada *</label>
+              <select class="q10-form-select" id="wz-mat-sedejornada">
+                <option value="">— Seleccionar —</option>${sedejornadaOpts || '<option value="" disabled>No hay sede-jornadas</option>'}
+              </select>
             </div>
             <div class="q10-form-group"><label class="q10-form-label">Condición de Matrícula *</label>
-              <input class="q10-form-input" id="wz-mat-condicion" placeholder="Valor exacto desde Q10 UI">
-              <div style="font-size:11px;color:#6B7280;margin-top:4px;">Enum Q10 (ej.: "Nuevo"/"Antiguo"). Valor exato vindo da UI Q10.</div>
+              <select class="q10-form-select" id="wz-mat-condicion">
+                <option value="">— Seleccionar —</option>${condicionOpts || '<option value="" disabled>No hay condiciones</option>'}
+              </select>
             </div>
             <div class="q10-form-group">
               <label style="display:flex;align-items:center;gap:8px;font-size:14px;color:#111;cursor:pointer;">


### PR DESCRIPTION
## Summary
Fixes **5 additional bugs** in payloads and endpoints, all discovered by live-probing the real Q10 Jack API against the geniusidiomas tenant. These were the root cause of the wizard and activity-registration flows being silently broken.

> **⚠️ Depends on #1** — base branch is `fix/bug-01-medios-estado-boolean`. Merge #1 first, then this PR will auto-retarget to `master`.

## Bugs fixed

| Bug | Endpoint | Root cause | Fix |
|---|---|---|---|
| **BUG-02** | `createEstudiante` | Posted to `/usuarios` (wants `Codigo_persona`); field `Tipo_identificacion` should be `Codigo_tipo_identificacion`; missing required `Codigo_programa` | Switch to `POST /estudiantes`; rename field; add `Codigo_programa` dropdown in wizard Case 1; dropdowns now populate from real `/tiposidentificacion`, `/sexos`, `/programas` |
| **BUG-03** | `createActividad` | Entire payload was wrong (`Tipo`/`Descripcion`/`Fecha`/`Codigo_oportunidad`/`Observaciones` instead of real schema) | Rewrite payload with `Consecutivo_negocio`, `Estado_actividad`, `Tipo_actividad`, `Numero_identificacion_asesor`, `Fecha_actividad`. Asesor ID auto-injected from storage |
| **BUG-04** | `createMatricula` | Handler did not exist in service-worker (silent "Unknown action"); payload missing 5 of 8 required fields | Add SW handler for `POST /matriculasProgramas`; rewrite payload; wizard Case 3 gains `Nivel`, `Fecha_matricula`, `Sede-Jornada`, `Condicion_matricula`, `Formalizada` |
| **BUG-05** | `createInscripcion` | Sent `Codigo_periodo` but API expects `Consecutivo_periodo` (int) | Rename field; value comes from `/periodos` `Consecutivo` (not `Codigo`) |
| **BUG-06** | `createOrdenPago` | Tenants without modelo financeiro return 400 `"La API no aplica para el modelo financiero"` and the wizard crashed | Catch this specific error and show a friendly info toast; wizard completes without cobro |

## Extras included in this PR
- Added new catalogs to `fetchCatalogs()`: `/jornadas`, `/niveles?Estado=true`, `/tiposidentificacion`, `/sexos`
- Per-endpoint errors in `fetchCatalogs` now `console.warn` instead of being silently swallowed
- `/periodos` dropdown now uses `Consecutivo` (int) — matches how API expects it on POST
- `/jornadas` dropdown now populated from the real catalog (was hardcoded `Diurna/Nocturna/Sabatina/Virtual`, none of which exist in the Q10 tenant)
- **Options page** gains a new "Identificación del asesor" field — saved as `q10AsesorId` in `chrome.storage.sync`. Service worker auto-injects it on `createOportunidad` and `createActividad` bodies.
- Wizard Case 0 now preserves `Primer_nombre`, `Primer_apellido`, `Email`, `Celular`, `Numero_identificacion` in `wizardState.results.contacto` so downstream steps can build correct payloads.
- `createOrdenPago` case added to service-worker.

## Known limitations (left as text inputs, documented in UI hints)

Three Q10 enum fields have values that are **not exposed by the API** — brute-force probing of 15+ common Spanish terms all returned validation errors:
- `Estado_actividad` and `Tipo_actividad` (BUG-03) — valid values must be read from the Q10 UI; the modal now has text inputs with hint text until we can hardcode or configure the valid list.
- `Condicion_matricula` (BUG-04) — same situation.
- `Consecutivo_sede_jornada` (BUG-04) — no `/sedes-jornadas` endpoint exists; number input with hint pointing to `/cursos` → `Consecutivo_sede_jornada` as reference.

These block the end-to-end flow on fresh tenants. Follow-up PR should fetch these once we have the Q10 admin values.

## Test plan

### Wizard "crear lead → estudiante"
- [ ] Reload extension; open Options page; fill in `Identificación del asesor`; save
- [ ] Open WhatsApp Web + side panel
- [ ] Open wizard for a new contact
- [ ] **Case 0 (Contacto)**: fill `Primer Nombre`, `Primer Apellido`, Email and Celular; submit; verify contact created
- [ ] **Case 1 (Estudiante)**: verify `Tipo de Identificación` dropdown shows Costa Rican codes (`CR01`, `CR02`), `Género` shows `M`/`F`, `Programa` shows `Curso de Português`; fill all required fields; submit; verify `POST /estudiantes` succeeds
- [ ] **Case 2 (Inscripción)**: verify `Jornada` dropdown shows `Mañana`/`Tarde`/`Noche`/`Sábado`; `Periodo` dropdown shows `2025`/`2026`; submit; verify inscripcion record created
- [ ] **Case 3 (Matrícula)**: fill Nivel (A1-C2), Fecha, Sede-Jornada, Condicion, Formalizada; submit (will fail with enum error until user provides valid `Condicion_matricula`)
- [ ] **Case 4 (Cobro)**: enter concept/value/fecha; submit; verify friendly info toast "Cobro no disponible: esta institución no tiene modelo financiero" appears and wizard completes

### Actividad modal
- [ ] Open an existing contact with a known opportunity (must create opportunity first to get `Consecutivo_negocio`)
- [ ] Click "Registrar Actividad"
- [ ] Verify fields: `Consecutivo Negocio`, `Tipo`, `Estado`, `Descripción`
- [ ] Submit; expected to fail until valid enum values are known (this is expected — structure is correct)

### Oportunidade creation (unaffected, smoke test only)
- [ ] Verify create-oportunidad modal still works (Medio de contacto / Medio publicitario dropdowns populated from BUG-01 fix, now with asesor auto-injected)

## Follow-up work (separate PRs)
1. Discover valid enum values for `Estado_actividad`, `Tipo_actividad`, `Condicion_matricula` (requires Q10 admin access to read configured values)
2. Discover or derive `Consecutivo_sede_jornada` values (could be derived from `/cursos` response)
3. Auto-create a `Consecutivo_negocio` on first WhatsApp interaction if the contact has none (enables one-click activity logging)
4. Remove remaining `.catch(() => [])` silencers; surface errors visibly in UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)