### PR TITLE
docs: add README, architecture, Q10 API notes and contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,104 @@
+# Como contribuir
+
+Obrigado pelo interesse. Regras para manter a qualidade e evitar repetir dores passadas.
+
+## Regra de ouro: sem mocks, sempre API real
+
+**Nunca crie mocks do Q10 para testar.** A primeira iteração do plugin fez isso e o resultado foram campos com nomes errados, enums fora do padrão e bugs que só apareciam em produção. Toda mudança que toca integração com Q10 deve ser validada contra a API real usando `curl` ou o próprio plugin.
+
+Se você não tem API key de um tenant de teste, peça uma ao mantenedor. Não invente stubs "só pra rodar o código".
+
+Ver [docs/q10-api-notes.md](docs/q10-api-notes.md) para o método de descoberta de schema e os invariantes já validados.
+
+## Antes de abrir PR
+
+1. **Rode `node --check`** nos arquivos alterados:
+   ```bash
+   node --check background/service-worker.js
+   node --check sidepanel/sidepanel.js
+   node --check options/options.js
+   ```
+2. **Recarregue a extensão no Chrome** (`chrome://extensions` → botão reload) e teste o fluxo afetado em `web.whatsapp.com`.
+3. **Rode `git diff --check`** para pegar whitespace suspeito.
+4. **Se tocar payload de API**, valide com `curl` contra tenant de desenvolvimento. Exemplo:
+   ```bash
+   KEY='...'
+   curl -H "X-Q10-Key: $KEY" -H "Content-Type: application/json" \
+     -X POST -d '{}' https://geniusidiomas.com/api/q10/actividades
+   # espere receber 400 listando os campos obrigatórios
+   ```
+
+## Convenções de código
+
+### Escape de HTML
+
+Qualquer valor dinâmico (API do Q10, input de usuário, dados do WhatsApp) que entra em `innerHTML` **deve** passar por escape:
+
+```js
+// Texto entre tags:
+`<div>${htmlText(d.Email)}</div>`
+
+// Atributo HTML:
+`<input value="${htmlAttr(pf.Nombre)}">`
+
+// Opção de dropdown:
+`<option value="${escHtml(p.Codigo)}">${escHtml(p.Nombre)}</option>`
+```
+
+- `htmlText(valor, fallback)` — para conteúdo de texto; fallback default é `—`
+- `htmlAttr(valor)` — para valor de atributo
+- `escHtml(valor)` — escape cru (usado por dropdowns com formatação custom)
+
+Para conteúdo que não vem de `innerHTML`, prefira **`textContent`** direto:
+```js
+el.textContent = msg; // seguro por definição
+```
+
+### Payloads para Q10
+
+- `Estado` em query params e bodies é **sempre boolean** (`true`/`false`), nunca string.
+- Nomes de campos da Q10 API são **exatamente** como na doc oficial (ex.: `Codigo_tipo_identificacion`, não `Tipo_identificacion`).
+- Celular no `Detalle[]` limitado a 12 dígitos — use `phone.replace(/\D/g, '').slice(-12)`.
+- `Numero_identificacion_asesor` vem de `chrome.storage.sync['q10AsesorId']` — não hardcode.
+
+### Error handling
+
+- **Não silencie erros** com `.catch(() => [])`. Use pelo menos `console.warn('[Q10]', e.message)`.
+- Erros de API com mensagens específicas (ex.: "modelo financiero") devem virar mensagens amigáveis no toast ao invés de quebrar o fluxo.
+
+### Estilo
+
+- JavaScript vanilla. Sem frameworks, sem transpile, sem bundler.
+- Indentação: 2 espaços.
+- Aspas simples em strings JS. Template literals para interpolação.
+- Comentários em português ou inglês — escolha e seja consistente no arquivo.
+
+## Fluxo de PR
+
+1. Crie branch a partir de `master` (ou da PR pai se for stack): `fix/descricao-curta` ou `feat/descricao-curta`
+2. Commit com mensagens que expliquem o **porquê** (não só o que):
+   ```
+   fix: medios dropdowns use Estado=true boolean (BUG-01)
+
+   The Q10 API rejects Estado='Activo' (string) with HTTP 400
+   "The value 'Activo' is not valid for Nullable`1". Changed to
+   Estado=true (boolean) per live API validation.
+   ```
+3. Abra PR com:
+   - **Summary** (1-3 bullets)
+   - **Evidence** quando possível — output de curl, screenshot, linha do código
+   - **Test plan** (checklist do que verificar no browser)
+   - **Follow-ups** se deixar algo explicitamente fora de escopo
+4. Responda aos comments do review no mesmo commit quando possível (não abra PR nova para cada ciclo).
+
+## Para mudanças grandes
+
+Abra **issue** primeiro descrevendo o problema e a abordagem proposta. Especialmente para:
+- Migração de proxy → API oficial
+- Refatoração de `sidepanel.js` (o arquivo tem ~1.6k linhas e é conhecido como precisando quebrar)
+- Novos fluxos do CRM (por exemplo, suporte a renovação de matrícula)
+
+## Segredos
+
+- **Nunca** commite API keys, dumps de dados reais de Q10 (com nomes/emails), ou arquivos `.env`.
+- Use `curl` inline com variável de ambiente: `KEY='...' curl -H "X-Q10-Key: $KEY" ...`.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,149 @@
+# Q10 CRM para WhatsApp Web
+
+Extensão Chrome (Manifest V3) que integra o **Q10 Académico** dentro do **WhatsApp Web**. Detecta automaticamente o contato da conversa ativa, cruza com o CRM do Q10 e expõe ações de atendimento (criar lead, registrar atividade, matricular estudante, gerar cobro) num painel lateral — sem o vendedor precisar alternar entre abas.
+
+- **Versão:** 3.4.0
+- **Plataforma:** Chrome / Edge / Brave (MV3, side panel API)
+- **Alvo:** `https://web.whatsapp.com/*`
+- **Backend:** Q10 Jack API (via proxy `geniusidiomas.com/api/q10` — ver [docs/q10-api-notes.md](docs/q10-api-notes.md))
+
+---
+
+## Para quem é
+
+**Vendedores de escola** que atendem leads pelo WhatsApp e precisam atualizar o CRM a cada interação. O plugin elimina o custo de alternar entre abas e evita perda de histórico.
+
+Hoje o plugin cobre 4 fluxos principais:
+
+| Fluxo | O que faz |
+|---|---|
+| **Consultar** | Detecta o telefone/nome da conversa ativa, busca em estudiantes/contactos/oportunidades do Q10 e mostra dados no painel lateral |
+| **Criar lead** | Modal de criação rápida de contacto + oportunidade (com medio de contacto/publicitario) |
+| **Matricular** | Wizard de 5 passos: contacto → estudiante → inscripción → matrícula → cobro |
+| **Registrar atividade** | Modal para logar cada interação (Llamada/WhatsApp/Correo/Nota/Reunión) vinculada ao negocio da oportunidade |
+
+---
+
+## Instalação
+
+### Pré-requisitos
+
+- Google Chrome, Edge ou Brave (última versão)
+- Conta ativa no Q10 Académico (`app.q10.com`)
+- API key do Q10 (`Ocp-Apim-Subscription-Key`) — gere em **Configuración → Integraciones → API**
+- Seu `Numero_identificación` de administrativo no Q10 (visível em **Administrativos → seu perfil**)
+
+### Passos
+
+1. Clone o repositório ou baixe o ZIP:
+   ```bash
+   git clone https://github.com/diogenesmendes01/q10-whatsapp-plugin.git
+   ```
+2. No Chrome, abra `chrome://extensions` e ative **Modo desenvolvedor** (canto superior direito).
+3. Clique em **Carregar sem compactação** e selecione a pasta `q10-whatsapp-plugin`.
+4. O ícone do Q10 deve aparecer na barra de extensões.
+
+### Configuração
+
+1. Clique direito no ícone da extensão → **Opções** (ou `chrome://extensions` → **Detalhes** → **Opções da extensão**).
+2. Cole sua **API Key** (Ocp-Apim-Subscription-Key) e clique em **Salvar**.
+3. (Após PR #2 ser merged) Selecione seu nome no dropdown **Asesor** e salve.
+4. Clique em **Testar Conexão** para confirmar.
+
+---
+
+## Como usar
+
+1. Abra `https://web.whatsapp.com` e aguarde o login.
+2. Clique no ícone da extensão → abre o **painel lateral** do Chrome.
+3. Entre em qualquer conversa — o plugin detecta nome/telefone e busca no Q10.
+4. Se for **estudiante**: dados acadêmicos + financeiros (quando disponível).
+5. Se for **contacto/oportunidad**: pipeline + atividades recentes.
+6. Se **não encontrado**: botões para criar contacto ou oportunidade rapidamente.
+
+### Botões de ação disponíveis no painel
+
+- **Matricular Alumno** — abre wizard de 5 passos
+- **Crear Oportunidad** — cria lead rápido
+- **Registrar Actividad** — loga interação no CRM (precisa ter oportunidade já criada)
+- **Generar Cobro** — cria orden de pago (requer modelo financeiro ativo no tenant)
+- **Exportar Datos** — CSV de contactos/estudiantes/oportunidades
+- **Exportar Chat** — TXT com o histórico da conversa ativa
+
+---
+
+## Estrutura do projeto
+
+```
+q10-whatsapp-plugin/
+├── manifest.json              # MV3 manifest
+├── background/
+│   └── service-worker.js      # API proxy, caching, orquestração
+├── content/
+│   └── content.js             # Bridge page ↔ extensão
+├── inject/
+│   ├── loader.js              # Extrai Store interno do WhatsApp
+│   └── inject.js              # Lê chat ativo (nome+telefone)
+├── sidepanel/
+│   ├── sidepanel.html         # UI container
+│   └── sidepanel.js           # Render + wizard + modais (~1.6k linhas)
+├── options/
+│   ├── options.html           # Página de configurações
+│   └── options.js             # API key + asesor picker
+├── popup/                     # [DESUSADO] extension clique abre side panel em vez de popup
+├── styles/                    # CSS (sidepanel, content)
+└── icons/                     # Extension icons
+```
+
+Veja [docs/architecture.md](docs/architecture.md) para o data flow detalhado entre os 5 contextos (page, content script, service worker, side panel, options).
+
+---
+
+## Desenvolvimento
+
+**Regra de ouro:** seguir a [documentação oficial do Q10 Jack API](https://developer.q10.com/api-details#api=jack-api) e **testar contra a API real** — nunca criar mocks. Ver [CONTRIBUTING.md](CONTRIBUTING.md).
+
+### Recarregar após mudar código
+
+1. `chrome://extensions` → clique no ícone de recarregar na extensão
+2. Recarregue `web.whatsapp.com` também (F5)
+
+### Validar sintaxe
+
+```bash
+node --check background/service-worker.js
+node --check sidepanel/sidepanel.js
+node --check options/options.js
+```
+
+### Convenções da Q10 API
+
+- Base URL do proxy: `https://geniusidiomas.com/api/q10` (aceita header `X-Q10-Key`)
+- Base URL oficial: `https://api.q10.com/v1` (aceita header `Api-Key`)
+- Payloads aceitam `Estado` como **boolean** (`true`/`false`), **não** string (`'Activo'`)
+- Endpoints com nomes surpreendentes: `/condicionesMatricula` (camelCase), `/sedesjornadas` (sem hífen)
+
+Detalhes completos em [docs/q10-api-notes.md](docs/q10-api-notes.md).
+
+---
+
+## Limitações conhecidas
+
+- **Tenants sem modelo financeiro Q10** → `/facturas`, `/ordenespago`, `/estadocuentaestudiantes` retornam HTTP 400. O plugin degrada graciosamente e mostra aviso no wizard de cobro.
+- **Valores de enum configuráveis por tenant** (`Tipo_actividad`, `Estado_actividad`, `Condicion_matricula`) — hoje usam os valores padrão Q10; para tenants que customizaram, podem precisar ajuste.
+- **Busca de "estudiantes" via `/usuarios`** — a doc oficial tem `/estudiantes`, mas essa rota retorna 404 no proxy atual. Acesso a detalhes completos usa `/estudiantes/{id}` que funciona individualmente.
+- **Apenas web.whatsapp.com** — não funciona em WhatsApp Business Desktop nem no app mobile.
+
+---
+
+## Segurança
+
+- A API key é armazenada em `chrome.storage.sync` (sincronizada entre dispositivos do mesmo user Chrome, criptografada pela plataforma).
+- Dados dinâmicos (nomes, emails, telefones do Q10) passam por escape HTML antes de renderizar no side panel.
+- Ao limpar a API key nas opções, o `q10AsesorId` também é removido para evitar injeção cruzada de tenant.
+
+---
+
+## Licença
+
+Uso interno. Entre em contato com o mantenedor antes de redistribuir.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,177 @@
+# Arquitetura
+
+Este doc explica como os **5 contextos de execução** do Chrome MV3 se encaixam neste plugin e como a mensagem sai do DOM do WhatsApp até o Q10.
+
+## Diagrama de componentes
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        web.whatsapp.com                         │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │  PAGE CONTEXT (JS da SPA do WhatsApp)                    │   │
+│  │  ┌──────────────────────┐                                │   │
+│  │  │ inject/loader.js     │  injetado via <script> tag     │   │
+│  │  │  ↓ encontra Store    │                                │   │
+│  │  │ inject/inject.js     │  lê Store.Chat / Store.Contact │   │
+│  │  └────────┬─────────────┘                                │   │
+│  │           │ postMessage({action:'phoneChanged', ...})    │   │
+│  │           ↓                                              │   │
+│  │  ┌──────────────────────┐                                │   │
+│  │  │ ISOLATED CONTEXT     │  ← content script              │   │
+│  │  │ content/content.js   │                                │   │
+│  │  └────────┬─────────────┘                                │   │
+│  └───────────┼──────────────────────────────────────────────┘   │
+└──────────────┼──────────────────────────────────────────────────┘
+               │ chrome.runtime.sendMessage
+               ↓
+┌─────────────────────────────────────────────────────────────────┐
+│  EXTENSION CONTEXT                                              │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ background/service-worker.js                              │  │
+│  │  - getApiKey() / getAsesorId() from chrome.storage.sync   │  │
+│  │  - apiGet / apiPost (com cache de 5min)                   │  │
+│  │  - message handlers (searchPhone, createOportunidad, ...) │  │
+│  └────┬──────────────────────────────┬───────────────────────┘  │
+│       │ fetch()                      │ chrome.runtime.onMessage │
+│       ↓                              ↑                          │
+│  ┌────────────────┐         ┌────────┴──────────────────────┐   │
+│  │ Q10 Jack API   │         │ sidepanel/sidepanel.js        │   │
+│  │ (via proxy)    │         │  - render (estudiante/        │   │
+│  └────────────────┘         │     contacto/oportunidad)     │   │
+│                             │  - wizard 5-step              │   │
+│                             │  - modais (oportunidad,       │   │
+│                             │     actividad, cobro)         │   │
+│                             └───────────────────────────────┘   │
+│                             ┌───────────────────────────────┐   │
+│                             │ options/options.js            │   │
+│                             │  - API key form               │   │
+│                             │  - asesor dropdown            │   │
+│                             │  - test connection            │   │
+│                             └───────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Por que tantos contextos?
+
+- **Chrome MV3** isola cada script num mundo próprio. O code da SPA do WhatsApp (page context) não pode falar direto com o service worker da extensão.
+- Para ler o `window.Store` interno do WhatsApp (que tem `Chat.Active`, `Contact`, etc.), precisamos estar no **page context** — content script não tem acesso direto.
+- Para chamar a API Q10 sem CORS, o service worker faz a requisição de dentro da extensão.
+
+**Caminho de uma mensagem:**
+1. WhatsApp SPA troca chat ativo
+2. `inject.js` (page ctx) detecta via `Store.Chat` mutation
+3. `inject.js` faz `window.postMessage({phone, name})` que só o `content.js` escuta (origem = mesma página)
+4. `content.js` faz `chrome.runtime.sendMessage({action:'phoneChanged',...})`
+5. Service worker salva em `chrome.storage.session` e o side panel (aberto) faz a busca via nova mensagem
+
+---
+
+## Service worker — API layer
+
+[`background/service-worker.js`](../background/service-worker.js) centraliza tudo que toca rede ou storage persistente. As responsabilidades:
+
+### Caching
+
+```js
+const cache = new Map();             // chave: `endpoint|JSON.stringify(params)`
+const CACHE_TTL = 5 * 60 * 1000;     // 5 min padrão
+const CACHE_TTL_SHORT = 60 * 1000;   // 1 min para dados financeiros
+```
+
+Cada `apiGet` serializa endpoint+params como chave, verifica TTL, retorna do cache se fresh. `clearCache` action esvazia tudo (chamada pelo botão "Recarregar" da tela de opções quando troca de API key).
+
+### Handlers suportados (`chrome.runtime.onMessage`)
+
+| Action | Faz |
+|---|---|
+| `searchPhone` / `searchName` | Busca em `/usuarios` (role=Estudiante), depois `/contactos` |
+| `fetchCatalogs` | 11 GETs em paralelo para popular dropdowns do wizard |
+| `fetchAdministrativos` | Lista asesores para o dropdown da página de opções |
+| `fetchStudentFinancials` | `/estadocuentaestudiantes` com cache curto |
+| `fetchMedios` | Atalho para mediospublicitarios + medioscontacto |
+| `createContacto` | `POST /contactos` |
+| `createEstudiante` | `POST /estudiantes` (⚠ master antigo apontava para `/usuarios` — ver BUG-02) |
+| `createInscripcion` | `POST /inscripciones` |
+| `createMatricula` | `POST /matriculasProgramas` |
+| `createOportunidad` | `POST /oportunidades` (auto-injeta `Numero_identificacion_asesor`) |
+| `createActividad` | `POST /actividades` (auto-injeta asesor e `Fecha_actividad` default) |
+| `createOrdenPago` | `POST /ordenespago` |
+| `exportAll` | Dump de contactos+usuarios para CSV |
+| `exportConversation` | Encaminha para content script fazer DOM scrape |
+
+### Normalização
+
+- **Telefone**: `replace(/\D/g, '')` + remove leading zero + mata country code quando > 12 dígitos
+- **Nome**: `.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '')` (ignora acentos no match)
+
+---
+
+## Side panel — UI principal
+
+[`sidepanel/sidepanel.js`](../sidepanel/sidepanel.js) é quase tudo: ~1.6k linhas com render, wizard e modais. Estrutura interna:
+
+```js
+(function () {
+  // ---------- HELPERS ----------
+  function el(tag, cls, html) { ... }        // createElement + set innerHTML
+  function escHtml(s) { ... }                // HTML entities
+  function htmlText(value, fallback) { ... } // text content helper
+  function htmlAttr(value) { ... }           // attribute helper
+  function fullNameHtml(d) { ... }           // escape nome de pessoa
+
+  // ---------- RENDER ----------
+  function renderEstudiante(result) { ... }
+  function renderOportunidad(result) { ... }
+  function renderContacto(data) { ... }
+  function renderNoConversation() { ... }
+  function renderError(msg) { ... }
+  function renderLoading(msg) { ... }
+
+  // ---------- WIZARD 5-step ----------
+  function renderWizardStep() { ... }        // switch em wizardState.step
+  function submitWizardStep() { ... }
+
+  // ---------- MODALS ----------
+  function showCreateOportunidadModal(phone, name) { ... }
+  function showCreateContactoModal(phone, name) { ... }
+  function showCreateActividadModal(contactData) { ... }
+  function showCobroModal(studentData) { ... }
+
+  // ---------- TAGS + NOTES (local, chrome.storage.local) ----------
+  function renderTagsSection(contactId, tags) { ... }
+  async function renderNotesSection(contactId) { ... }
+})();
+```
+
+### Estado mantido
+
+- `catalogsCache` — resultado de `fetchCatalogs`, reutilizado entre wizards sem rebuscar
+- `wizardState` — `{step, phone, prefill, results: {contacto, estudiante, inscripcion, matricula, cobro}}`
+- `currentPhone` / `currentContactName` / `currentResult` — última busca ativa
+
+### XSS hardening
+
+Qualquer dado vindo de `/administrativos`, `/contactos`, `/programas`, etc. que for interpolado em `innerHTML` passa por `escHtml` ou `htmlText`/`htmlAttr`. Toasts usam `textContent`. Ver [PR #4](https://github.com/diogenesmendes01/q10-whatsapp-plugin/pull/4) para o histórico completo.
+
+---
+
+## Options page
+
+[`options/options.js`](../options/options.js) salva 2 chaves em `chrome.storage.sync`:
+- `q10ApiKey` — Ocp-Apim-Subscription-Key
+- `q10AsesorId` — `Numero_identificacion` do vendedor (selecionado via dropdown)
+
+Lógica especial:
+- Dropdown de asesor só habilita após a API key ser salva (fetch `/administrativos` via SW)
+- Quando a API key é alterada e o asesor salvo não está na nova lista, **`q10AsesorId` é auto-removido** (protege contra injeção cruzada de tenant)
+- Botão 🔄 invalida o cache (clearCache) e re-busca
+
+---
+
+## Popup — desusado
+
+A pasta [`popup/`](../popup/) existe mas não é referenciada no `manifest.json` (não tem `default_popup` na action). Clicar no ícone da extensão abre o **side panel** graças a `chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true })` em `service-worker.js:34`.
+
+O código de popup pode ser removido em cleanup futuro.

--- a/docs/q10-api-notes.md
+++ b/docs/q10-api-notes.md
@@ -1,0 +1,253 @@
+# Q10 Jack API — notas práticas
+
+Este arquivo captura **invariantes validados ao vivo** contra a API real do Q10. É complemento à doc oficial (`https://developer.q10.com/api-details#api=jack-api`), que lista os 179 endpoints mas **não expõe schemas nem valores de enum**.
+
+Última validação: 2026-04-21 (tenant `geniusidiomas`).
+
+---
+
+## Conventions
+
+### Hosts e autenticação
+
+| Host | Header de auth | Observação |
+|---|---|---|
+| `https://geniusidiomas.com/api/q10` | `X-Q10-Key` | Proxy do cliente — usado pelo plugin atualmente |
+| `https://api.q10.com/v1` | `Api-Key` | API oficial Azure APIM — **rejeita** `X-Q10-Key` com 401 |
+
+A mesma key funciona nos dois hosts e retorna os mesmos dados. Migração proxy → oficial é viável, só precisa trocar base URL + header.
+
+### Tipos de valor
+
+- **`Estado`** em query params e bodies é **boolean** (`true`/`false`). Enviar string `"Activo"` retorna:
+  ```json
+  {"code":"4001","message":"...","validationErrors":{"Estado":["The value 'Activo' is not valid for Nullable`1."]}}
+  ```
+- **`Consecutivo_*`** são **inteiros** na query mas a API aceita string (ex.: `?Consecutivo_periodo=2`).
+- Datas são ISO 8601 curto: `"2026-04-20"` (sem horário) ou `"2026-04-20T09:27:30.93"` (retorno).
+
+### HTTP status
+
+- `401` — "invalid subscription key" (auth real, não fallback silencioso)
+- `400` + `code: "4001"` — erro de validação de schema (inclui lista `validationErrors` por campo)
+- `400` + `code: "400"` — outras validações (params obrigatórios, modelo financeiro, etc.)
+- `404` — endpoint não existe ou modelo não se aplica ao tipo de instituição (ex.: `/annoslectivos` em ETDH)
+
+---
+
+## Endpoints que o plugin usa
+
+### Catálogos (GET, read-only)
+
+| Endpoint | Query obrigatória | Retorna |
+|---|---|---|
+| `/administrativos` | — | Lista de pessoas administrativas (asesores) |
+| `/programas` | — | Programas acadêmicos |
+| `/periodos` | — | Períodos letivos (com `Consecutivo` int) |
+| `/sedes` | — | Filiais |
+| `/jornadas` | — | Turnos (Mañana/Tarde/Noche/Sábado) |
+| `/sedesjornadas` | — | Combos sede×jornada (com `Consecutivo` único) |
+| `/niveles` | `?Estado=true` | Níveis acadêmicos (A1-C2 em escolas de idiomas) |
+| `/tiposidentificacion` | — | Tipos de documento (CR01, CR02, etc.) |
+| `/sexos` | — | `F`/`M` |
+| `/mediospublicitarios` | `?Estado=true` | Origens de lead (Facebook, Instagram, etc.) |
+| `/medioscontacto` | `?Estado=true` | Canais de contato (WhatsApp, etc.) |
+| `/condicionesMatricula` | `?Estado=true` | Condições de matrícula (ver enum abaixo) |
+| `/flujonegocios` | `?Estado=true` | Estados do pipeline CRM |
+| `/causas` | `?Estado=true` | Causas de perda de oportunidade |
+| `/oportunidad/campospersonalizados` | `?Estado=true` | Campos customizados do CRM |
+
+### Entidades (GET individual)
+
+- `GET /estudiantes/{id}` — detalhe de aluno (`id` = Codigo_persona). **`/estudiantes` (lista) retorna 404**, mas o detalhe funciona.
+- `GET /usuarios/{id}` — detalhe de usuário-login (diferente de estudante).
+- `GET /oportunidades/{Consecutivo_oportunidad}` — inclui `Negocio_favorito.Consecutivo_negocio` embutido.
+- `GET /negocios/{Consecutivo_negocio}` — detalhe do negocio.
+- `GET /actividades?Consecutivo_negocio={id}` — histórico de interações de um negocio.
+
+### Listas com filtro obrigatório
+
+| Endpoint | Param obrigatório | Nota |
+|---|---|---|
+| `GET /oportunidades` | `Fecha_inicio` + `Fecha_fin` | Sem as duas datas → 404 |
+| `GET /negocios` | Pelo menos 1 param de filtro | Sem nenhum → 400 "ingresar al menos un parámetro" |
+| `GET /inscripciones` | Pelo menos 1 filtro | 400 "No se ha ingresado ningún filtro" |
+
+### Criação (POST)
+
+#### POST /contactos
+
+Cria um lead. Schema mínimo:
+
+```json
+{
+  "Consecutivo_oportunidad": 0,
+  "Nombres": "Maria Silva",
+  "Apellidos": "Oliveira",
+  "Detalle": [
+    { "Tipo_detalle": "Email", "Descripcion": "maria@ex.com" },
+    { "Tipo_detalle": "Celular", "Descripcion": "5519988145438" }
+  ]
+}
+```
+
+- `Detalle` aceita apenas `Tipo_detalle: "Celular"` ou `"Email"` (tentar `"Telefono"` não funciona)
+- Campo `Descripcion` do Celular é limitado a **12 dígitos** — normalize com `raw.replace(/\D/g, '').slice(-12)`.
+
+#### POST /oportunidades
+
+```json
+{
+  "Nombre_oportunidad": "João Silva - Curso Avançado",
+  "Numero_identificacion_asesor": "00000"
+}
+```
+
+Cria automaticamente 1 `Negocio_favorito` em estado inicial do pipeline (Presentación).
+
+#### POST /actividades
+
+Registra interação vinculada a um negocio. **Todos os campos abaixo são obrigatórios:**
+
+```json
+{
+  "Consecutivo_negocio": 6,
+  "Estado_actividad": "C",
+  "Tipo_actividad": "WhatsApp",
+  "Numero_identificacion_asesor": "00000",
+  "Fecha_actividad": "2026-04-20",
+  "Resultado_actividad": "Cliente interessado, agendar visita"
+}
+```
+
+Enum `Estado_actividad` (códigos de 1 letra, **não o label visível**):
+- `"C"` = Completada → também exige `Resultado_actividad`
+- `"P"` = Programada → também exige `Descripcion_actividad`
+
+Enum `Tipo_actividad` (valores descobertos via screenshot da UI):
+- `"Llamada"`, `"WhatsApp"`, `"Correo"`, `"Nota"`, `"Reunión"`
+
+⚠️ Mandar o label visível (`"Completada"` em vez de `"C"`) retorna **400** "El campo Estado_actividad es inválido". O mesmo vale para `Tipo_resultado` se o tenant tiver enum customizado.
+
+#### POST /estudiantes
+
+```json
+{
+  "Primer_nombre": "Cristian",
+  "Primer_apellido": "Reyes",
+  "Codigo_tipo_identificacion": "CR01",
+  "Numero_identificacion": "208120496",
+  "Genero": "M",
+  "Email": "x@y.com",
+  "Celular": "50660528900",
+  "Fecha_nacimiento": "2000-12-29",
+  "Codigo_programa": "01"
+}
+```
+
+#### POST /inscripciones
+
+Schema mínimo é só `Codigo_estudiante`, mas na prática envie também `Codigo_programa` e `Consecutivo_periodo` (inteiro, **não** `Codigo_periodo`).
+
+#### POST /matriculasProgramas
+
+Fluxo mais complexo — **8 campos obrigatórios:**
+
+```json
+{
+  "Consecutivo_inscripcion": 123,
+  "Codigo_estudiante": "...",
+  "Fecha_matricula": "2026-04-20",
+  "Consecutivo_sede_jornada": 1,
+  "Consecutivo_periodo": 2,
+  "Codigo_nivel": "01",
+  "Condicion_matricula": "N",
+  "Formalizada": true
+}
+```
+
+Enum `Condicion_matricula` (GET `/condicionesMatricula?Estado=true` retorna a lista — 13 valores neste tenant):
+
+| Codigo | Nombre |
+|---|---|
+| `N` | Nuevo |
+| `RG` | Antiguo |
+| `RI` | Reingresante |
+| `TE` | Transferencia Externa |
+| `TI` | Transferencia Interna |
+| `CP` | Ciclo propedéutico |
+| `DP` | Doble Programa |
+| `EA` | Estudiante de Articulación |
+| `SPP` | Estudiantes SPP |
+| `OG` | Opción de grado |
+| `IA` | Semestre de intercambio académico |
+| `ES` | Transferencia entre seccionales |
+| `TC` | Co-Titulación o Titulación Conjunta |
+
+**API quer o `Codigo` (1-3 letras), não o `Nombre`.**
+
+#### POST /ordenespago
+
+⚠️ **Bloqueado em tenants sem modelo financeiro ativo.** Retorna:
+```json
+{"code":"400","message":"La API no aplica para el modelo financiero de la institución."}
+```
+
+O plugin detecta essa mensagem e mostra aviso ao invés de quebrar o fluxo.
+
+---
+
+## Pipeline CRM (estados do negocio)
+
+`GET /flujonegocios?Estado=true` retorna 5 estados padrão:
+
+| `Consecutivo_estado_negocio` | Nombre | Porcentaje |
+|---|---|---|
+| 1 | Perdido | 0 |
+| 2 | Presentación | 20 |
+| 4 | En negociación | 50 |
+| 3 | Cierre | 80 |
+| 5 | Ganado | 100 |
+
+Transições:
+- `PATCH /negocios/estado` — mover entre estados não-terminais
+- `PUT /negocios/estado/ganar` — marca como Ganado
+- `PUT /negocios/estado/perder` — marca como Perdido (exige `Consecutivo_causa_perdida` de `/causas`)
+
+---
+
+## Metodologia de descoberta de schema
+
+Quando a doc oficial não lista campos obrigatórios, use esta receita:
+
+1. **`POST /{endpoint}` com body `{}`** — retorna 400 listando os campos obrigatórios.
+   ```bash
+   curl -X POST -H "X-Q10-Key: $KEY" -H "Content-Type: application/json" \
+     -d '{}' "$BASE/actividades"
+   # {"code":"400","message":"Los siguientes campos son obligatorios: Consecutivo_negocio, Estado_actividad, ..."}
+   ```
+
+2. **POST com placeholder em campo enum** — se retornar "es inválido", o nome do campo está certo mas o valor é restrito. Procure endpoint de catálogo correspondente (ex.: `Condicion_matricula` → `/condicionesMatricula`).
+
+3. **POST com um campo por vez** — cada 400 revela o próximo campo faltando. Itere até passar.
+
+4. **Se enum não tem endpoint** (ex.: `Estado_actividad`, `Tipo_actividad`), extraia da UI Q10 com screenshot do formulário de criação. **A API espera `Codigo` (geralmente 1-3 letras), não o label visível.**
+
+---
+
+## Pegadinhas documentadas
+
+- **`/estudiantes` (lista) → 404** no proxy. Use `/estudiantes/{id}` individual ou filtre `/usuarios` por role `"Estudiante"`.
+- **`/paises` → 404** no tenant testado. Use valores hardcoded se precisar.
+- **`/sedes-jornadas` (com hífen) → 404.** O endpoint certo é `/sedesjornadas`.
+- **`/annoslectivos` → 400** em instituições ETDH/Superior (só aplica a colegios).
+- **`/facturas`, `/ordenespago`, `/estadocuentaestudiantes` → 400** se tenant não tem módulo financeiro.
+- **`Tipo_detalle` em contactos:** só `"Celular"` e `"Email"`. `"Telefono"` é silenciosamente aceito mas não persiste no Q10.
+- **Nomes de asesor podem ter acentos HTML-quebráveis** (ex.: `Vitor Falcão`) — sempre escape antes de renderizar.
+
+---
+
+## Referências
+
+- Doc oficial: `https://developer.q10.com/api-details#api=jack-api` (Azure APIM, requer login + JS)
+- Export completo local: `~/Downloads/Q10-JACK-API.md` (179 operações listadas)


### PR DESCRIPTION
## Summary

Repo tinha **zero documentação**. Essa PR adiciona quatro docs capturando tudo que foi aprendido nos PRs #1, #2 e #4 — incluindo o trabalho de descoberta de API que levou horas e vários commits para destravar.

## Arquivos

| Arquivo | Para quem | Cobre |
|---|---|---|
| [README.md](README.md) (149 linhas) | Todo mundo | Pitch, instalação, setup, uso, estrutura, limitações, segurança |
| [docs/architecture.md](docs/architecture.md) (177 linhas) | Dev novo | Diagrama dos 5 contextos MV3, fluxo de mensagem WhatsApp → Q10, handlers do SW, estrutura interna do sidepanel, nota sobre popup desusado |
| [docs/q10-api-notes.md](docs/q10-api-notes.md) (253 linhas) | Dev que toca API | Hosts/headers, tipos de valor (Estado boolean), endpoints que o plugin usa, schemas de POST com campos obrigatórios, **enum values** (Estado_actividad C/P, Tipo_actividad, Condicion_matricula com 13 códigos), metodologia de descoberta, pegadinhas |
| [CONTRIBUTING.md](CONTRIBUTING.md) (104 linhas) | Contribuidor | Regra "sem mocks, sempre API real", checklist pré-PR, escape conventions, estilo de código, fluxo de PR |

Total: 683 linhas adicionadas em 4 arquivos novos. Nenhuma linha de código alterada.

## Por que agora

- Após 4 PRs sem docs, onboarding de novo dev seria hostil.
- Descobertas da API real (enums de actividade, `Condicion_matricula`, `/sedesjornadas` sem hífen, tenants sem modelo financeiro) estavam só na memória dos commits — risco de re-descobrir tudo daqui a 6 meses.
- A regra "sem mocks" precisava ficar escrita em algum lugar visível além dos commits e dos comentários inline.

## Test plan

- [ ] Abrir README no GitHub e conferir que links e tabelas renderizam
- [ ] Conferir que o diagrama ASCII em `docs/architecture.md` não quebrou em markdown
- [ ] Validar que a tabela de 13 condições de matrícula em `docs/q10-api-notes.md` está completa
- [ ] Ajustar qualquer referência a tenant de teste se for exposição indesejada

## Não inclui (propositalmente)

- Screenshots/GIFs da UI (seria bom mas ficaria pesado; podemos adicionar em PR separada)
- CHANGELOG.md — `git log` serve por enquanto
- JSDoc inline — o código já tem comentários decentes nos pontos críticos (ex.: fixes marcados com BUG-XX)
- LICENSE — assumindo uso interno; adicionar quando/se abrir

## Notas

- PR aponta direto para `master` (não depende dos fixes pendentes das PRs #2/#4)
- Doc menciona PR #2 como "em flight" para o feature de asesor dropdown. Quando #2 mergear, um update opcional pode remover essa observação.

🤖 Generated with [Claude Code](https://claude.com/claude-code)