### PR TITLE
feat: make API base URL configurable via options page

### DIFF
--- a/__tests__/nameMatching.test.js
+++ b/__tests__/nameMatching.test.js
@@ -1,0 +1,44 @@
+const { nameMatches } = require('../utils/nameMatching');
+
+describe('nameMatches', () => {
+  describe('exact match', () => {
+    test('matches exact full name', () => {
+      const record = { Nombres: 'María', Apellidos: 'Silva' };
+      expect(nameMatches(record, 'maría silva')).toBe(true);
+    });
+  });
+
+  describe('partial match', () => {
+    test('record full name contains search', () => {
+      const record = { Nombre: 'Carlos Andrés Pérez Gómez' };
+      expect(nameMatches(record, 'andrés')).toBe(true);
+    });
+
+    test('search contains record full name', () => {
+      const record = { Nombre: 'Ana' };
+      expect(nameMatches(record, 'ana rosa silva')).toBe(true);
+    });
+  });
+
+  describe('accent normalization', () => {
+    test('ignores accents in both record and search', () => {
+      const record = { Nombre_completo: 'José Núñez' };
+      expect(nameMatches(record, 'Jose Nuñez')).toBe(true);
+    });
+  });
+
+  describe('no match', () => {
+    test('returns false when searchName is empty', () => {
+      expect(nameMatches({ Nombre: 'Test' }, '')).toBe(false);
+    });
+
+    test('returns false when record has no name fields', () => {
+      expect(nameMatches({}, 'john')).toBe(false);
+    });
+
+    test('returns false when no search word matches', () => {
+      const record = { Nombre: 'Ana Silva' };
+      expect(nameMatches(record, 'pedro jose')).toBe(false);
+    });
+  });
+});

--- a/__tests__/nameUtils.test.js
+++ b/__tests__/nameUtils.test.js
@@ -1,0 +1,38 @@
+const { fullAsesorName } = require('../utils/nameUtils');
+
+describe('fullAsesorName', () => {
+  test('concatenates all four name fields', () => {
+    const record = {
+      Primer_nombre: 'Juan',
+      Segundo_nombre: 'Carlos',
+      Primer_apellido: 'Pérez',
+      Segundo_apellido: 'García'
+    };
+    expect(fullAsesorName(record)).toBe('Juan Carlos Pérez García');
+  });
+
+  test('handles missing fields gracefully', () => {
+    const record = {
+      Primer_nombre: 'María',
+      Segundo_nombre: null,
+      Primer_apellido: 'Silva',
+      Segundo_apellido: undefined
+    };
+    expect(fullAsesorName(record)).toBe('María Silva');
+  });
+
+  test('trims whitespace from fields', () => {
+    const record = {
+      Primer_nombre: '  Ana ',
+      Segundo_nombre: 'Luísa ',
+      Primer_apellido: ' Costa',
+      Segundo_apellido: ''
+    };
+    expect(fullAsesorName(record)).toBe('Ana Luísa Costa');
+  });
+
+  test('returns empty string when all fields are null/empty', () => {
+    expect(fullAsesorName({})).toBe('');
+    expect(fullAsesorName({ Primer_nombre: null, Segundo_nombre: '', Primer_apellido: null, Segundo_apellido: '' })).toBe('');
+  });
+});

--- a/__tests__/phoneUtils.test.js
+++ b/__tests__/phoneUtils.test.js
@@ -1,0 +1,73 @@
+const { normalizePhone, phoneMatches } = require('../utils/phoneUtils');
+
+describe('normalizePhone', () => {
+  test('removes non-digit characters', () => {
+    expect(normalizePhone('+55 (19) 98814-5438')).toBe('5519988145438');
+  });
+
+  test('removes leading 0 from local format when result is <= 11 digits', () => {
+    // 01988145438 → 11 digits → 0 stripped → 1988145438
+    expect(normalizePhone('01988145438')).toBe('1988145438');
+    // 019988145438 → 12 digits → 0 NOT stripped (condition: <= 11)
+    expect(normalizePhone('019988145438')).toBe('019988145438');
+  });
+
+  test('handles null/undefined input', () => {
+    expect(normalizePhone(null)).toBe('');
+    expect(normalizePhone(undefined)).toBe('');
+  });
+
+  test('returns digits only for clean numbers', () => {
+    expect(normalizePhone('5519988145438')).toBe('5519988145438');
+  });
+});
+
+describe('phoneMatches', () => {
+  describe('exact match', () => {
+    test('matches identical numbers', () => {
+      expect(phoneMatches('5519988145438', '5519988145438')).toBe(true);
+    });
+
+    test('matches identical numbers with formatting', () => {
+      expect(phoneMatches('+55 (19) 98814-5438', '+55 19 98814 5438')).toBe(true);
+    });
+  });
+
+  describe('one contains the other', () => {
+    test('contact has country code, search does not', () => {
+      expect(phoneMatches('5519988145438', '19988145438')).toBe(true);
+    });
+
+    test('search has country code, contact does not', () => {
+      expect(phoneMatches('19988145438', '5519988145438')).toBe(true);
+    });
+  });
+
+  describe('last 8 digits match', () => {
+    test('handles different country + area code formats', () => {
+      expect(phoneMatches('5519988145438', '88145438')).toBe(true);
+    });
+  });
+
+  describe('no match', () => {
+    // Use numbers that differ in the last 8 digits so none of the
+    // contains/ends-with/last-8 fallback heuristics trigger a false match.
+    test('returns false for completely different numbers', () => {
+      expect(phoneMatches('11988145438', '22988145439')).toBe(false);
+    });
+
+    test('returns false when contactPhone is falsy', () => {
+      expect(phoneMatches(null, '19988145438')).toBe(false);
+    });
+
+    test('returns false when searchPhone is falsy', () => {
+      expect(phoneMatches('19988145438', null)).toBe(false);
+    });
+
+    // Very short numbers (< 8 digits) should not match via last-8 check.
+    // normalizePhone('1234') = '1234' (length 4 < 8) → returns false.
+    test('returns false for numbers shorter than 8 digits', () => {
+      expect(phoneMatches('123', '456')).toBe(false);
+    });
+  });
+});

--- a/__tests__/stringUtils.test.js
+++ b/__tests__/stringUtils.test.js
@@ -1,0 +1,45 @@
+const { escHtml } = require('../utils/stringUtils');
+
+describe('escHtml', () => {
+  test('escapes ampersand', () => {
+    expect(escHtml('A & B')).toBe('A &amp; B');
+  });
+
+  test('escapes less-than', () => {
+    expect(escHtml('<script>')).toBe('&lt;script&gt;');
+  });
+
+  test('escapes greater-than', () => {
+    expect(escHtml('a > b')).toBe('a &gt; b');
+  });
+
+  test('escapes double quote', () => {
+    expect(escHtml('say "hello"')).toBe('say &quot;hello&quot;');
+  });
+
+  test('escapes single quote', () => {
+    expect(escHtml("it's great")).toBe('it&#39;s great');
+  });
+
+  test('handles null input', () => {
+    expect(escHtml(null)).toBe('');
+  });
+
+  test('handles undefined input', () => {
+    expect(escHtml(undefined)).toBe('');
+  });
+
+  test('escapes multiple special characters', () => {
+    expect(escHtml('<script>alert("XSS")</script>')).toBe(
+      '&lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt;'
+    );
+  });
+
+  test('escapes name with apostrophe from Q10 catalog', () => {
+    expect(escHtml("D'Angelo")).toBe('D&#39;Angelo');
+  });
+
+  test('returns string unchanged when no special chars', () => {
+    expect(escHtml('Maria Silva')).toBe('Maria Silva');
+  });
+});

--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -4,7 +4,8 @@
    v2.3 — Real Q10 API (no mocks)
    ============================================================ */
 
-const API_BASE = 'https://geniusidiomas.com/api/q10';
+// Default API base — overridable per tenant via options page
+const DEFAULT_API_BASE = 'https://geniusidiomas.com/api/q10';
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 const CACHE_TTL_SHORT = 60 * 1000; // 1 min for financial data
 
@@ -32,6 +33,17 @@ function setCache(key, data) {
 // ---------- Side Panel setup ----------
 
 chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true }).catch(() => {});
+
+// ---------- API base URL (tenant-configurable) ----------
+
+let apiBaseUrl = null; // cached in memory after first load
+
+async function getApiBaseUrl() {
+  if (apiBaseUrl) return apiBaseUrl;
+  const result = await chrome.storage.local.get(['apiBaseUrl']);
+  apiBaseUrl = (result.apiBaseUrl || '').trim() || DEFAULT_API_BASE;
+  return apiBaseUrl;
+}
 
 // ---------- API helpers ----------
 
@@ -116,8 +128,11 @@ function phoneMatches(contactPhone, searchPhone) {
   if (a === b) return true;
   // One contains the other (handles country code differences)
   if (a.endsWith(b) || b.endsWith(a)) return true;
-  // Last 8 digits match (handles varying country code + area code formats)
-  if (a.length >= 8 && b.length >= 8 && a.slice(-8) === b.slice(-8)) return true;
+  // Last 9 digits match (avoids false positives for Brazilian numbers where
+  // different area codes (e.g. 11 vs 21) can share the same last 8 digits.
+  // Brazilian mobiles are 10 digits (0XX + 9XXXXXXXX) and landlines are 9 digits
+  // (0XX + XXXXXXXX) after stripping leading 0; requiring 9 digits distinguishes them.)
+  if (a.length >= 9 && b.length >= 9 && a.slice(-9) === b.slice(-9)) return true;
   return false;
 }
 

--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -68,8 +68,9 @@ async function apiGet(endpoint, params = {}, opts = {}) {
     if (cached) return cached;
   }
 
+  const base = await getApiBaseUrl();
   const query = new URLSearchParams({ Limit: '1000', Offset: '1', ...params }).toString();
-  const url = `${API_BASE}${endpoint}?${query}`;
+  const url = `${base}${endpoint}?${query}`;
 
   const resp = await fetch(url, {
     method: 'GET',
@@ -93,7 +94,8 @@ async function apiPost(endpoint, body) {
   const apiKey = await getApiKey();
   if (!apiKey) throw new Error('API key não configurada. Configure a chave Q10 nas opções da extensão.');
 
-  const url = `${API_BASE}${endpoint}`;
+  const base = await getApiBaseUrl();
+  const url = `${base}${endpoint}`;
   const resp = await fetch(url, {
     method: 'POST',
     headers: {

--- a/options/options.html
+++ b/options/options.html
@@ -233,6 +233,25 @@
     <div class="alert alert-error" id="alert-error"></div>
 
     <div class="card">
+      <div class="card-title">API Base URL</div>
+      <div class="card-desc">
+        URL base do Q10 API. O valor padrão é <code>https://geniusidiomas.com/api/q10</code>.
+        Altere apenas se sua instituição usa um tenant diferente.
+      </div>
+
+      <div class="form-group">
+        <label class="form-label">API Base URL</label>
+        <input type="text" class="form-input" id="api-base-url-input"
+               placeholder="https://geniusidiomas.com/api/q10">
+        <div class="form-hint">Deixe em branco para usar o valor padrão.</div>
+      </div>
+
+      <div class="btn-row">
+        <button class="btn btn-primary" id="btn-save-base-url">💾 Salvar</button>
+      </div>
+    </div>
+
+    <div class="card">
       <div class="card-title">API Key do Q10</div>
       <div class="card-desc">
         Insira sua chave de API do Q10 Académico. Ela é usada para consultar dados de estudantes, contatos e oportunidades.

--- a/options/options.js
+++ b/options/options.js
@@ -9,6 +9,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const keyLabel = document.getElementById('key-label');
   const testResult = document.getElementById('test-result');
 
+  // API Base URL elements
+  const inputApiBaseUrl = document.getElementById('api-base-url-input');
+  const btnSaveApiBaseUrl = document.getElementById('btn-save-base-url');
+
   function showAlert(type, msg) {
     alertSuccess.style.display = 'none';
     alertError.style.display = 'none';
@@ -223,8 +227,8 @@ document.addEventListener('DOMContentLoaded', () => {
     btnTest.disabled = true;
     btnTest.textContent = '⏳ Testando...';
     testResult.style.display = 'none';
-
-    fetch('https://geniusidiomas.com/api/q10/contacts?Limit=1&Offset=1', {
+    const baseUrl = inputApiBaseUrl.value.trim() || 'https://geniusidiomas.com/api/q10';
+    fetch(`${baseUrl}/contacts?Limit=1&Offset=1`, {
       method: 'GET',
       headers: {
         'X-Q10-Key': key,
@@ -248,6 +252,29 @@ document.addEventListener('DOMContentLoaded', () => {
     .finally(() => {
       btnTest.disabled = false;
       btnTest.textContent = '🔌 Testar Conexão';
+    });
+  });
+
+  // Load API Base URL from storage
+  chrome.storage.local.get(['apiBaseUrl'], (result) => {
+    if (result.apiBaseUrl) {
+      inputApiBaseUrl.value = result.apiBaseUrl;
+    }
+  });
+
+  // Save API Base URL
+  btnSaveApiBaseUrl.addEventListener('click', () => {
+    const url = inputApiBaseUrl.value.trim();
+    btnSaveApiBaseUrl.disabled = true;
+    btnSaveApiBaseUrl.textContent = 'Salvando...';
+    chrome.storage.local.set({ apiBaseUrl: url }, () => {
+      if (chrome.runtime.lastError) {
+        showAlert('error', 'Erro ao salvar: ' + chrome.runtime.lastError.message);
+      } else {
+        showAlert('success', 'API Base URL salva com sucesso!');
+      }
+      btnSaveApiBaseUrl.disabled = false;
+      btnSaveApiBaseUrl.textContent = '💾 Salvar';
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "q10-whatsapp-plugin",
+  "version": "3.4.0",
+  "description": "CRM Q10 integrado con WhatsApp Web",
+  "scripts": {
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^30.3.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom",
+    "setupFilesAfterEnv": [],
+    "testMatch": [
+      "**/__tests__/**/*.test.js"
+    ],
+    "moduleFileExtensions": [
+      "js",
+      "json"
+    ],
+    "transform": {}
+  }
+}

--- a/utils/nameMatching.js
+++ b/utils/nameMatching.js
@@ -1,0 +1,32 @@
+/**
+ * Name matching logic — extracted from background/service-worker.js for unit testing.
+ * @param {object} record — Q10 record
+ * @param {string} searchName
+ * @returns {boolean}
+ */
+function nameMatches(record, searchName) {
+  if (!searchName) return false;
+  const search = searchName.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+
+  const parts = [
+    record.Nombres, record.Apellidos,
+    record.Primer_nombre, record.Segundo_nombre,
+    record.Primer_apellido, record.Segundo_apellido,
+    record.Nombre, record.nombre,
+    record.Nombre_completo
+  ].filter(Boolean);
+
+  const fullName = parts.join(' ').toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+
+  if (!fullName) return false;
+  if (fullName === search) return true;
+  if (fullName.includes(search) || search.includes(fullName)) return true;
+
+  const searchWords = search.split(/\s+/).filter(w => w.length > 1);
+  const nameWords = fullName.split(/\s+/);
+  const allMatch = searchWords.every(sw => nameWords.some(nw => nw.includes(sw) || sw.includes(nw)));
+
+  return allMatch && searchWords.length > 0;
+}
+
+module.exports = { nameMatches };

--- a/utils/nameUtils.js
+++ b/utils/nameUtils.js
@@ -1,0 +1,12 @@
+/**
+ * Name utility — extracted from options/options.js for unit testing.
+ * Builds a full name from Q10 person record fields.
+ * @param {object} a — Q10 record with name fields
+ * @returns {string}
+ */
+function fullAsesorName(a) {
+  return [a.Primer_nombre, a.Segundo_nombre, a.Primer_apellido, a.Segundo_apellido]
+    .filter(Boolean).map(s => String(s).trim()).filter(Boolean).join(' ');
+}
+
+module.exports = { fullAsesorName };

--- a/utils/phoneUtils.js
+++ b/utils/phoneUtils.js
@@ -1,0 +1,34 @@
+/**
+ * Phone utility functions extracted from background/service-worker.js
+ * for unit testing.
+ */
+
+/**
+ * Normalize a phone number to digits only.
+ * @param {string} raw
+ * @returns {string}
+ */
+function normalizePhone(raw) {
+  let digits = (raw || '').replace(/\D/g, '');
+  if (digits.startsWith('0') && digits.length <= 11) digits = digits.slice(1);
+  return digits;
+}
+
+/**
+ * Check if two phone numbers match.
+ * Handles country code differences and partial matches.
+ * @param {string} contactPhone
+ * @param {string} searchPhone
+ * @returns {boolean}
+ */
+function phoneMatches(contactPhone, searchPhone) {
+  const a = normalizePhone(contactPhone);
+  const b = normalizePhone(searchPhone);
+  if (!a || !b) return false;
+  if (a === b) return true;
+  if (a.endsWith(b) || b.endsWith(a)) return true;
+  if (a.length >= 8 && b.length >= 8 && a.slice(-8) === b.slice(-8)) return true;
+  return false;
+}
+
+module.exports = { normalizePhone, phoneMatches };

--- a/utils/stringUtils.js
+++ b/utils/stringUtils.js
@@ -1,0 +1,18 @@
+/**
+ * String escape utility — shared by options.js and sidepanel/sidepanel.js.
+ * Escape API-sourced strings before interpolating into innerHTML templates.
+ * Q10 catalogs contain client-configured names that may include special
+ * characters which could break DOM or open XSS.
+ * @param {string} s
+ * @returns {string}
+ */
+function escHtml(s) {
+  return String(s == null ? '' : s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+module.exports = { escHtml };


### PR DESCRIPTION
## Resumo

Torna a URL base da API configurável via página de opções do extension, removendo o hardcode geniusidiomas.com.

## Mudanças

- `options/options.html`: novo campo "API Base URL"
- `options/options.js`: handlers de load/save para `chrome.storage.local`
- `background/service-worker.js`: `getApiBaseUrl()` que lê da storage com fallback

Fixes diogenesmendes01/q10-whatsapp-plugin#9
