### PR TITLE
fix: add abstraction layer for WhatsApp Store API with graceful degradation

### DIFF
--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -128,9 +128,12 @@ function nameMatches(record, searchName) {
   const search = searchName.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
   
   // Build full name from record fields
-  const parts = [
-    record.Nombres, record.Apellidos,
-    record.Primer_nombre, record.Segundo_nombre,
+  // Last 9 digits match (avoids false positives for Brazilian numbers where
+  // different area codes (e.g. 11 vs 21) can share the same last 8 digits.
+  // Brazilian mobiles are 10 digits (0XX + 9XXXXXXXX) and landlines are 9 digits
+  // (0XX + XXXXXXXX) after stripping leading 0; requiring 9 digits distinguishes them.)
+  if (a.length >= 9 && b.length >= 9 && a.slice(-9) === b.slice(-9)) return true;
+  return false;
     record.Primer_apellido, record.Segundo_apellido,
     record.Nombre, record.nombre,
     record.Nombre_completo

--- a/inject/inject.js
+++ b/inject/inject.js
@@ -1,18 +1,18 @@
 /* ============================================================
    Q10 CRM — Inject Script (WhatsApp Web)
-   Runs in PAGE context to access WhatsApp Web's internal
-   Store API for reliable chat/contact detection.
+   Uses the Q10StoreAdapter abstraction layer for safe access
+   to WhatsApp Web's internal Store APIs.
 
    Communication: window.postMessage ↔ content script
 
-   v1.0 — Store-based detection + DOM fallback
+   v2.0 — Q10StoreAdapter-based detection + DOM fallback
    ============================================================ */
 
 (function () {
   'use strict';
 
-  const TAG = '[Q10 Inject]';
-  const CHAT_CHANGE_DEBOUNCE = 300; // ms
+  var TAG = '[Q10 Inject]';
+  var CHAT_CHANGE_DEBOUNCE = 300; // ms
 
   // Avoid double-init
   if (window.__q10InjectReady) {
@@ -21,50 +21,39 @@
   }
   window.__q10InjectReady = true;
 
-  let lastChatId = null;
-  let debounceTimer = null;
-  let storeAvailable = false;
+  var lastChatId = null;
+  var debounceTimer = null;
+  var storeAvailable = false;
+  var chatUnsubscribe = null;
 
-  // ================================================================
-  //  STORE-BASED CHAT DETECTION
-  // ================================================================
+  // ──────────────────────────────────────────────────────────────
+  //  STORE-BASED CHAT DETECTION (via Q10StoreAdapter)
+  // ──────────────────────────────────────────────────────────────
 
   /**
-   * Get the currently active chat using the Store API.
-   * Returns null if Store is not available or no chat is open.
+   * Get the currently active chat using the Q10StoreAdapter.
+   * Returns null if Store is unavailable or no chat is open.
    */
   function getCurrentChatFromStore() {
     try {
-      const store = window.Q10Store;
-      if (!store || !store.Chat) return null;
+      var adapter = window.Q10StoreAdapter;
+      if (!adapter || !adapter.isAvailable()) return null;
+      if (adapter.isBroken()) return null;
 
-      // Find the active chat — it's the one with "active" or at position 0
-      // WhatsApp marks the selected chat differently across versions
-      let activeChat = null;
+      // Get active chat model
+      var activeChat = adapter.getActiveChat();
 
-      // Method 1: Chat.getActive (some versions)
-      if (typeof store.Chat.getActive === 'function') {
-        activeChat = store.Chat.getActive();
-      }
-
-      // Method 2: Look for Chat with active=true flag
-      if (!activeChat && typeof store.Chat.getModelsArray === 'function') {
-        const chats = store.Chat.getModelsArray();
-        activeChat = chats.find((c) => c.active || c.isActive);
-      }
-
-      // Method 3: Check the currently visible chat via the DOM chatId,
-      // then look it up in Store for rich data
+      // If no active, try looking up via DOM-detected chatId
       if (!activeChat) {
-        const chatId = getChatIdFromDOM();
-        if (chatId && typeof store.Chat.get === 'function') {
-          activeChat = store.Chat.get(chatId);
+        var chatId = getChatIdFromDOM();
+        if (chatId) {
+          activeChat = adapter.getChatById(chatId);
         }
       }
 
       if (!activeChat) return null;
 
-      return formatChatData(activeChat, store);
+      return formatChatData(activeChat, adapter);
     } catch (err) {
       console.warn(TAG, 'getCurrentChatFromStore error:', err.message);
       return null;
@@ -74,44 +63,36 @@
   /**
    * Format a Store chat model into the Q10 data shape.
    */
-  function formatChatData(chat, store) {
+  function formatChatData(chat, adapter) {
     try {
-      const id = chat.id?._serialized || chat.id?.toString() || '';
-      const isGroup = id.endsWith('@g.us');
-      const phone = isGroup ? null : cleanPhone(id);
+      var id = chat.id && chat.id._serialized ? chat.id._serialized : (chat.id && chat.id.toString ? chat.id.toString() : '');
+      var isGroup = id.endsWith('@g.us');
+      var phone = isGroup ? null : cleanPhone(id);
 
       // Get contact name (multiple fallbacks)
-      let name = null;
+      var name = null;
       if (chat.name) {
         name = chat.name;
       } else if (chat.formattedTitle) {
         name = chat.formattedTitle;
       } else if (chat.contact) {
-        name =
-          chat.contact.pushname ||
-          chat.contact.formattedName ||
-          chat.contact.name ||
-          chat.contact.shortName;
+        name = chat.contact.pushname || chat.contact.formattedName || chat.contact.name || chat.contact.shortName;
       }
 
-      // Try Store.Contact for better name data
-      if (!name && store.Contact && !isGroup) {
+      // Try adapter.getContactById() for better name data
+      if (!name && !isGroup && adapter && adapter.isAvailable()) {
         try {
-          const contact = store.Contact.get(chat.id);
+          var contact = adapter.getContactById(chat.id);
           if (contact) {
-            name =
-              contact.pushname ||
-              contact.formattedName ||
-              contact.name ||
-              contact.shortName;
+            name = contact.pushname || contact.formattedName || contact.name || contact.shortName;
           }
         } catch (_) { /* skip */ }
       }
 
-      // Profile pic (if available in model)
-      let profilePic = null;
+      // Profile pic
+      var profilePic = null;
       try {
-        profilePic = chat.contact?.profilePicThumb?.eurl || null;
+        profilePic = chat.contact && chat.contact.profilePicThumb && chat.contact.profilePicThumb.eurl ? chat.contact.profilePicThumb.eurl : null;
       } catch (_) { /* skip */ }
 
       return {
@@ -119,7 +100,7 @@
         name: name || null,
         isGroup: isGroup,
         chatId: id,
-        profilePic: profilePic,
+        profilePic: profilePic
       };
     } catch (err) {
       console.warn(TAG, 'formatChatData error:', err.message);
@@ -132,36 +113,29 @@
    */
   function cleanPhone(chatId) {
     if (!chatId) return null;
-    const match = chatId.match(/^(\d+)@/);
+    var match = chatId.match(/^(\d+)@/);
     return match ? match[1] : chatId.replace(/@.*$/, '').replace(/\D/g, '') || null;
   }
 
-  // ================================================================
+  // ──────────────────────────────────────────────────────────────
   //  DOM-BASED FALLBACKS
-  // ================================================================
+  // ──────────────────────────────────────────────────────────────
 
-  /**
-   * Try to extract the chat ID from the DOM.
-   * Used as a bridge to look up the chat in Store.
-   */
   function getChatIdFromDOM() {
     try {
-      // data-id on messages contains the chat ID
-      const msgEl = document.querySelector('#main [data-id]');
+      var msgEl = document.querySelector('#main [data-id]');
       if (msgEl) {
-        const dataId = msgEl.getAttribute('data-id') || '';
-        // Format: "true_5519988145438@c.us_XXXXXXX" or "false_..."
-        const match = dataId.match(/(?:true|false)_(\d+@\w+\.us)/);
+        var dataId = msgEl.getAttribute('data-id') || '';
+        var match = dataId.match(/(?:true|false)_(\d+@\w+\.us)/);
         if (match) return match[1];
       }
 
-      // conversation-panel-wrapper sometimes has data attributes
-      const panel = document.querySelector('[data-testid="conversation-panel-wrapper"]');
+      var panel = document.querySelector('[data-testid="conversation-panel-wrapper"]');
       if (panel) {
-        const attrs = Array.from(panel.attributes);
-        for (const attr of attrs) {
-          const match = attr.value.match(/(\d+@\w+\.us)/);
-          if (match) return match[1];
+        var attrs = Array.from(panel.attributes);
+        for (var i = 0; i < attrs.length; i++) {
+          var m = attrs[i].value.match(/(\d+@\w+\.us)/);
+          if (m) return m[1];
         }
       }
 
@@ -171,30 +145,24 @@
     }
   }
 
-  /**
-   * Pure DOM fallback: extract phone/name from header.
-   * Less reliable but works without Store.
-   */
   function getCurrentChatFromDOM() {
     try {
-      const headerEl = document.querySelector('#main header span');
+      var headerEl = document.querySelector('#main header span');
       if (!headerEl) return null;
 
-      const title = (headerEl.textContent || '').trim();
+      var title = (headerEl.textContent || '').trim();
       if (!title) return null;
 
-      const chatId = getChatIdFromDOM();
-      const cleanedPhone = cleanPhoneFromText(title);
-
-      // Determine if it's a group (groups have commas in participant list or no phone)
-      const isGroup = chatId ? chatId.endsWith('@g.us') : false;
+      var chatId = getChatIdFromDOM();
+      var cleanedPhone = cleanPhoneFromText(title);
+      var isGroup = chatId ? chatId.endsWith('@g.us') : false;
 
       return {
         phone: cleanedPhone || (chatId ? cleanPhone(chatId) : null),
-        name: cleanedPhone ? null : title, // If title is a phone, name is unknown
+        name: cleanedPhone ? null : title,
         isGroup: isGroup,
         chatId: chatId || null,
-        profilePic: null,
+        profilePic: null
       };
     } catch (err) {
       console.warn(TAG, 'getCurrentChatFromDOM error:', err.message);
@@ -202,27 +170,18 @@
     }
   }
 
-  /**
-   * Check if text looks like a phone number and clean it.
-   */
   function cleanPhoneFromText(text) {
-    const cleaned = (text || '').replace(/[\s\-\(\)\u200e\u200f\u202a\u202c+]/g, '');
+    var cleaned = (text || '').replace(/[\s\-\(\)\u200e\u200f\u202a\u202c+]/g, '');
     return /^\d{10,15}$/.test(cleaned) ? cleaned : null;
   }
 
-  // ================================================================
-  //  UNIFIED GETTER — Store first, DOM fallback
-  // ================================================================
-
   function getCurrentChat() {
-    let data = null;
+    var data = null;
 
-    // Try Store first
     if (storeAvailable) {
       data = getCurrentChatFromStore();
     }
 
-    // Fallback to DOM
     if (!data) {
       data = getCurrentChatFromDOM();
     }
@@ -230,35 +189,26 @@
     return data;
   }
 
-  // ================================================================
-  //  CHAT CHANGE OBSERVER
-  // ================================================================
+  // ──────────────────────────────────────────────────────────────
+  //  CHAT CHANGE OBSERVERS
+  // ──────────────────────────────────────────────────────────────
 
-  /**
-   * MutationObserver on #main to detect when user switches conversations.
-   * The #main element gets replaced/updated when switching chats.
-   */
   function startChatObserver() {
-    // Observe changes to the main chat area
-    const targetNode = document.getElementById('app') || document.body;
+    var targetNode = document.getElementById('app') || document.body;
 
-    const observer = new MutationObserver((mutations) => {
-      // Look for signals that the chat changed:
-      // - #main element added/replaced
-      // - header content changed
-      let chatMayHaveChanged = false;
+    var observer = new MutationObserver(function(mutations) {
+      var chatMayHaveChanged = false;
 
-      for (const mutation of mutations) {
-        // Check added nodes for #main or header changes
+      for (var i = 0; i < mutations.length; i++) {
+        var mutation = mutations[i];
         if (mutation.type === 'childList') {
-          for (const node of mutation.addedNodes) {
+          for (var j = 0; j < mutation.addedNodes.length; j++) {
+            var node = mutation.addedNodes[j];
             if (node.nodeType !== 1) continue;
             if (
               node.id === 'main' ||
-              node.querySelector?.('#main') ||
-              node.matches?.('#main header *') ||
-              node.querySelector?.('[data-testid="conversation-header"]') ||
-              node.querySelector?.('[data-testid="conversation-panel-wrapper"]')
+              (node.querySelector && (node.querySelector('#main') || node.querySelector('[data-testid="conversation-header"]') || node.querySelector('[data-testid="conversation-panel-wrapper"]'))) ||
+              (node.matches && node.matches('#main header *'))
             ) {
               chatMayHaveChanged = true;
               break;
@@ -266,11 +216,11 @@
           }
         }
 
-        // Attribute changes on header elements
         if (
           mutation.type === 'attributes' &&
           mutation.attributeName === 'title' &&
-          mutation.target.closest?.('#main header')
+          mutation.target.closest &&
+          mutation.target.closest('#main header')
         ) {
           chatMayHaveChanged = true;
         }
@@ -287,24 +237,20 @@
       childList: true,
       subtree: true,
       attributes: true,
-      attributeFilter: ['title'],
+      attributeFilter: ['title']
     });
 
-    console.log(TAG, 'Chat observer started on', targetNode.tagName + '#' + (targetNode.id || ''));
+    console.log(TAG, 'DOM chat observer started on', targetNode.tagName + '#' + (targetNode.id || ''));
     return observer;
   }
 
-  /**
-   * Debounced handler for chat changes.
-   * Prevents flooding when DOM updates rapidly during navigation.
-   */
   function debouncedChatChange() {
     clearTimeout(debounceTimer);
-    debounceTimer = setTimeout(() => {
-      const chat = getCurrentChat();
+    debounceTimer = setTimeout(function() {
+      var chat = getCurrentChat();
       if (!chat) return;
 
-      const newId = chat.chatId || chat.phone || chat.name;
+      var newId = chat.chatId || chat.phone || chat.name;
       if (newId && newId !== lastChatId) {
         lastChatId = newId;
         console.log(TAG, 'Chat changed →', chat.name || chat.phone, chat.isGroup ? '(group)' : '');
@@ -313,107 +259,107 @@
     }, CHAT_CHANGE_DEBOUNCE);
   }
 
-  // ================================================================
-  //  STORE-BASED CHAT OBSERVER (more reliable when available)
-  // ================================================================
-
   /**
-   * If Store is available, listen for chat model changes.
-   * This is more reliable than DOM observation.
+   * Store-based chat observer via Q10StoreAdapter.
+   * Uses event subscription when available, polling as fallback.
    */
   function startStoreObserver() {
-    try {
-      const store = window.Q10Store;
-      if (!store || !store.Chat) return false;
+    var adapter = window.Q10StoreAdapter;
+    if (!adapter || !adapter.isAvailable()) return false;
 
-      // Some versions have an 'on' or 'addListener' method
-      if (typeof store.Chat.on === 'function') {
-        store.Chat.on('change:active', () => {
-          console.log(TAG, 'Store: active chat changed');
-          debouncedChatChange();
-        });
-        console.log(TAG, 'Store-based chat observer started');
-        return true;
-      }
+    // Try event subscription first
+    var unsubscribe = adapter.onActiveChatChange(function() {
+      console.log(TAG, 'Store: active chat changed');
+      debouncedChatChange();
+    });
 
-      // Alternative: poll the active chat via Store
-      setInterval(() => {
-        const chat = getCurrentChatFromStore();
-        if (!chat) return;
-
-        const newId = chat.chatId || chat.phone || chat.name;
-        if (newId && newId !== lastChatId) {
-          lastChatId = newId;
-          console.log(TAG, 'Store poll: chat changed →', chat.name || chat.phone);
-          broadcastChatData(chat);
-        }
-      }, 1000);
-
-      console.log(TAG, 'Store polling observer started (1s interval)');
+    if (unsubscribe) {
+      chatUnsubscribe = unsubscribe;
+      console.log(TAG, 'Store-based chat observer started (event subscription)');
       return true;
-    } catch (err) {
-      console.warn(TAG, 'startStoreObserver error:', err.message);
-      return false;
     }
+
+    // Fallback: polling via adapter
+    setInterval(function() {
+      if (!storeAvailable) return;
+      var chat = getCurrentChatFromStore();
+      if (!chat) return;
+
+      var newId = chat.chatId || chat.phone || chat.name;
+      if (newId && newId !== lastChatId) {
+        lastChatId = newId;
+        console.log(TAG, 'Store poll: chat changed →', chat.name || chat.phone);
+        broadcastChatData(chat);
+      }
+    }, 1000);
+
+    console.log(TAG, 'Store-based chat observer started (polling, 1s interval)');
+    return true;
   }
 
-  // ================================================================
-  //  COMMUNICATION — postMessage
-  // ================================================================
+  // ──────────────────────────────────────────────────────────────
+  //  STORE BREAKAGE DETECTION
+  // ──────────────────────────────────────────────────────────────
 
-  /**
-   * Send chat data to the content script via postMessage.
-   */
+  function startBreakageObserver() {
+    window.addEventListener('message', function(event) {
+      if (event.source !== window) return;
+      if (event.data && event.data.type === 'Q10_STORE_BROKEN') {
+        console.warn(TAG, 'Store API breakage detected — switching to DOM fallback');
+        storeAvailable = false;
+        if (chatUnsubscribe) {
+          try {
+            chatUnsubscribe();
+          } catch (_) { /* ignore */ }
+          chatUnsubscribe = null;
+        }
+      }
+    });
+  }
+
+  // ──────────────────────────────────────────────────────────────
+  //  COMMUNICATION — postMessage
+  // ──────────────────────────────────────────────────────────────
+
   function broadcastChatData(data) {
     if (!data) return;
-
-    window.postMessage(
-      {
-        type: 'Q10_CHAT_DATA',
-        data: data,
-      },
-      '*'
-    );
+    window.postMessage({ type: 'Q10_CHAT_DATA', data: data }, '*');
   }
 
-  /**
-   * Listen for requests from the content script.
-   */
   function startMessageListener() {
-    window.addEventListener('message', (event) => {
-      // Only handle messages from the same window
+    window.addEventListener('message', function(event) {
       if (event.source !== window) return;
 
-      const msg = event.data;
+      var msg = event.data;
       if (!msg || typeof msg !== 'object') return;
 
       switch (msg.type) {
         case 'Q10_GET_CURRENT_CHAT': {
-          const chat = getCurrentChat();
+          var chat = getCurrentChat();
           broadcastChatData(chat);
           break;
         }
 
         case 'Q10_PING': {
-          window.postMessage(
-            {
-              type: 'Q10_PONG',
-              storeAvailable: storeAvailable,
-              currentChat: getCurrentChat(),
-            },
-            '*'
-          );
+          var adapter = window.Q10StoreAdapter;
+          window.postMessage({
+            type: 'Q10_PONG',
+            storeAvailable: storeAvailable,
+            storeBroken: adapter ? adapter.isBroken() : true,
+            currentChat: getCurrentChat()
+          }, '*');
           break;
         }
 
         case 'Q10_GET_CHAT_BY_ID': {
-          if (msg.chatId && storeAvailable && window.Q10Store?.Chat) {
+          var adapter = window.Q10StoreAdapter;
+          if (msg.chatId && storeAvailable && adapter && adapter.isAvailable()) {
             try {
-              const chatModel = window.Q10Store.Chat.get(msg.chatId);
+              var chatModel = adapter.getChatById(msg.chatId);
               if (chatModel) {
-                broadcastChatData(formatChatData(chatModel, window.Q10Store));
+                broadcastChatData(formatChatData(chatModel, adapter));
               }
-            } catch (_) { /* skip */ }
+            } catch (_) { /* ignore */ }
           }
           break;
         }
@@ -426,19 +372,19 @@
     console.log(TAG, 'Message listener started');
   }
 
-  // ================================================================
-  //  WAIT FOR #main TO EXIST (WhatsApp hasn't loaded chat yet)
-  // ================================================================
+  // ──────────────────────────────────────────────────────────────
+  //  WAIT FOR #main TO EXIST
+  // ──────────────────────────────────────────────────────────────
 
   function waitForMain() {
-    return new Promise((resolve) => {
-      const existing = document.getElementById('main');
+    return new Promise(function(resolve) {
+      var existing = document.getElementById('main');
       if (existing) {
         resolve();
         return;
       }
 
-      const observer = new MutationObserver((_, obs) => {
+      var observer = new MutationObserver(function(_, obs) {
         if (document.getElementById('main')) {
           obs.disconnect();
           resolve();
@@ -447,104 +393,65 @@
 
       observer.observe(document.body || document.documentElement, {
         childList: true,
-        subtree: true,
+        subtree: true
       });
 
-      // Timeout after 60 seconds — user may not have opened a chat yet
-      setTimeout(() => {
+      setTimeout(function() {
         observer.disconnect();
-        resolve(); // resolve anyway, observers will catch it later
+        resolve();
       }, 60000);
     });
   }
 
-  // ================================================================
+  // ──────────────────────────────────────────────────────────────
   //  INIT
-  // ================================================================
+  // ──────────────────────────────────────────────────────────────
 
-  async function init() {
+  function init() {
     console.log(TAG, 'Inject script starting...');
 
-    // 1. Start message listener immediately
     startMessageListener();
+    startBreakageObserver();
 
-    // 2. Wait for Store (loaded by loader.js)
-    const storeWait = new Promise((resolve) => {
-      // Check immediately
-      if (window.Q10Store) {
-        resolve(true);
-        return;
-      }
-
-      // Listen for store ready event from loader.js
-      const handler = (event) => {
-        if (event.data?.type === 'Q10_STORE_READY') {
-          window.removeEventListener('message', handler);
-          resolve(true);
-        }
-        if (event.data?.type === 'Q10_STORE_FALLBACK') {
-          window.removeEventListener('message', handler);
-          resolve(false);
-        }
-      };
-      window.addEventListener('message', handler);
-
-      // Timeout: proceed with DOM fallback after 30s
-      setTimeout(() => {
-        window.removeEventListener('message', handler);
-        resolve(false);
-      }, 30000);
-    });
-
-    storeAvailable = await storeWait;
+    // Check if adapter already available
+    var adapter = window.Q10StoreAdapter;
+    if (adapter && adapter.isAvailable()) {
+      storeAvailable = true;
+      console.log(TAG, 'Store already available');
+    } else if (adapter && adapter.isBroken()) {
+      storeAvailable = false;
+      console.log(TAG, 'Store marked broken before init');
+    }
 
     if (storeAvailable) {
-      console.log(TAG, '✅ Store available — using Store-based detection');
+      console.log(TAG, 'Using Store-based detection');
     } else {
-      console.log(TAG, '⚠️ Store not available — using DOM fallback');
+      console.log(TAG, 'Using DOM fallback');
     }
 
-    // 3. Wait for #main (a chat must be open)
-    await waitForMain();
+    waitForMain().then(function() {
+      startChatObserver(); // DOM observer (always)
 
-    // 4. Start observers
-    startChatObserver(); // DOM observer (always)
-
-    if (storeAvailable) {
-      startStoreObserver(); // Store observer (when available)
-    }
-
-    // 5. Detect initial chat
-    setTimeout(() => {
-      const initialChat = getCurrentChat();
-      if (initialChat) {
-        lastChatId = initialChat.chatId || initialChat.phone || initialChat.name;
-        console.log(
-          TAG,
-          'Initial chat:',
-          initialChat.name || initialChat.phone,
-          initialChat.isGroup ? '(group)' : ''
-        );
-        broadcastChatData(initialChat);
-      } else {
-        console.log(TAG, 'No chat open yet — waiting for user to open one.');
+      if (storeAvailable) {
+        startStoreObserver(); // Store observer (when available)
       }
-    }, 500);
 
-    // 6. Announce ready
-    window.postMessage(
-      {
-        type: 'Q10_INJECT_READY',
-        storeAvailable: storeAvailable,
-      },
-      '*'
-    );
+      // Detect initial chat
+      setTimeout(function() {
+        var initialChat = getCurrentChat();
+        if (initialChat) {
+          lastChatId = initialChat.chatId || initialChat.phone || initialChat.name;
+          console.log(TAG, 'Initial chat:', initialChat.name || initialChat.phone, initialChat.isGroup ? '(group)' : '');
+          broadcastChatData(initialChat);
+        } else {
+          console.log(TAG, 'No chat open yet — waiting for user to open one.');
+        }
+      }, 500);
 
-    console.log(TAG, '✅ Inject script ready');
+      window.postMessage({ type: 'Q10_INJECT_READY', storeAvailable: storeAvailable }, '*');
+      console.log(TAG, 'Inject script ready');
+    });
   }
 
-  // Kick off
-  init().catch((err) => {
-    console.error(TAG, 'Init failed:', err);
-  });
+  init();
 })();

--- a/inject/loader.js
+++ b/inject/loader.js
@@ -1,7 +1,11 @@
 /* ============================================================
    Q10 CRM — Store Loader (WhatsApp Web)
-   Finds and exposes WhatsApp Web's internal Store object
-   using multiple strategies with retry/fallback.
+   Resolves the WhatsApp Store via Q10StoreAdapter abstraction.
+
+   This loader:
+   1. Loads store-adapter.js into the page context
+   2. Calls Q10StoreAdapter.resolveStore() (auto-runs on adapter load)
+   3. Handles the Q10_ADAPTER_READY / Q10_ADAPTER_UNAVAILABLE events
 
    Runs in PAGE context (injected via <script> tag).
    ============================================================ */
@@ -9,280 +13,109 @@
 (function () {
   'use strict';
 
-  const TAG = '[Q10 Inject]';
-  const MAX_RETRIES = 50;        // ~25 seconds total
-  const RETRY_INTERVAL = 500;    // ms between retries
+  var TAG = '[Q10 Loader]';
+  var ADAPTER_INIT_TIMEOUT = 30000; // ms
 
   // Avoid double-init
-  if (window.__q10StoreLoaded) {
-    console.log(TAG, 'Store loader already running, skipping.');
+  if (window.__q10LoaderRunning) {
+    console.log(TAG, 'Loader already running, skipping.');
     return;
   }
-  window.__q10StoreLoaded = true;
+  window.__q10LoaderRunning = true;
 
-  /**
-   * The Store object we're looking for has these key collections:
-   * - Chat: active chats
-   * - Contact: contacts
-   * - Msg: messages
-   * - Conn: connection info
-   */
-  const STORE_MODULES = {
-    Chat:    (m) => m.Chat && m.Chat.get && m.Chat.getModelsArray,
-    Contact: (m) => m.Contact && m.Contact.get && m.Contact.getModelsArray,
-    Msg:     (m) => m.Msg && m.Msg.get,
-    Conn:    (m) => m.Conn && m.Conn.wid,
-    Cmd:     (m) => m.Cmd && m.Cmd.openChatBottom,
-  };
-
-  // Will hold the resolved Store
-  window.Q10Store = null;
-
-  // ================================================================
-  //  Strategy 1: Intercept webpackChunkwhatsapp_web_client push
-  // ================================================================
-  function strategyWebpackIntercept() {
-    return new Promise((resolve) => {
-      const chunk = window.webpackChunkwhatsapp_web_client;
-      if (!chunk) {
-        resolve(null);
+  // ──────────────────────────────────────────────────────────────
+  //  Load store-adapter.js (sets window.Q10StoreAdapter + auto-bootstraps)
+  // ──────────────────────────────────────────────────────────────
+  function loadAdapter() {
+    return new Promise(function(resolve) {
+      if (window.Q10StoreAdapter) {
+        resolve();
         return;
       }
 
-      console.log(TAG, 'Strategy 1: Intercepting webpack chunk push...');
-
-      let resolved = false;
-      const originalPush = chunk.push.bind(chunk);
-
-      chunk.push = function (args) {
-        const result = originalPush(args);
-
-        if (!resolved) {
-          // After a chunk is loaded, try to find store modules
-          const store = searchModulesInWebpack();
-          if (store) {
-            resolved = true;
-            chunk.push = originalPush; // restore
-            resolve(store);
-          }
-        }
-
-        return result;
+      var script = document.createElement('script');
+      script.src = chrome.runtime.getURL('inject/store-adapter.js');
+      script.type = 'text/javascript';
+      script.onload = function() {
+        console.log(TAG, 'store-adapter.js loaded');
+        resolve();
       };
-
-      // Also try immediately in case modules are already loaded
-      const immediate = searchModulesInWebpack();
-      if (immediate) {
-        resolved = true;
-        chunk.push = originalPush;
-        resolve(immediate);
-      }
-
-      // Timeout — don't hang forever on this strategy
-      setTimeout(() => {
-        if (!resolved) {
-          chunk.push = originalPush;
-          resolve(null);
-        }
-      }, 10000);
+      script.onerror = function() {
+        console.error(TAG, 'Failed to load store-adapter.js');
+        resolve();
+      };
+      (document.head || document.documentElement).appendChild(script);
     });
   }
 
-  // ================================================================
-  //  Strategy 2: Search through webpack require/modules
-  // ================================================================
-  function searchModulesInWebpack() {
-    try {
-      const chunk = window.webpackChunkwhatsapp_web_client;
-      if (!chunk || chunk.length === 0) return null;
+  // ──────────────────────────────────────────────────────────────
+  //  Wait for adapter to signal readiness / unavailability
+  // ──────────────────────────────────────────────────────────────
+  function waitForAdapterSignal() {
+    return new Promise(function(resolve) {
+      // Check if already resolved
+      if (window.Q10StoreAdapter && window.Q10StoreAdapter.isAvailable()) {
+        resolve(true);
+        return;
+      }
+      if (window.Q10StoreAdapter && window.Q10StoreAdapter.isBroken()) {
+        resolve(false);
+        return;
+      }
 
-      let modules = null;
-
-      // Inject a fake module to get access to the require function
-      const moduleId = '__q10_probe_' + Date.now();
-      chunk.push([
-        [moduleId],
-        {},
-        function (require) {
-          modules = require;
-        },
-      ]);
-
-      if (!modules || !modules.m) return null;
-
-      const store = {};
-      const moduleKeys = Object.keys(modules.m);
-
-      for (const key of moduleKeys) {
-        try {
-          const mod = modules(key);
-          if (!mod || typeof mod !== 'object') continue;
-
-          // Check each target module
-          for (const [name, test] of Object.entries(STORE_MODULES)) {
-            if (!store[name]) {
-              try {
-                if (test(mod)) {
-                  store[name] = mod[name];
-                }
-              } catch (_) { /* skip */ }
-            }
-          }
-
-          // Also check mod.default
-          if (mod.default && typeof mod.default === 'object') {
-            for (const [name, test] of Object.entries(STORE_MODULES)) {
-              if (!store[name]) {
-                try {
-                  if (test(mod.default)) {
-                    store[name] = mod.default[name];
-                  }
-                } catch (_) { /* skip */ }
-              }
-            }
-          }
-        } catch (_) {
-          // Some modules throw on access — skip
+      var handler = function(event) {
+        if (event.source !== window) return;
+        var type = event.data && event.data.type;
+        if (type === 'Q10_ADAPTER_READY') {
+          window.removeEventListener('message', handler);
+          window.removeEventListener('message', fallbackHandler);
+          clearTimeout(timeoutId);
+          resolve(true);
         }
-      }
-
-      // Need at minimum Chat to be useful
-      if (store.Chat) {
-        console.log(TAG, 'Found Store modules:', Object.keys(store).join(', '));
-        return store;
-      }
-
-      return null;
-    } catch (err) {
-      console.warn(TAG, 'searchModulesInWebpack error:', err.message);
-      return null;
-    }
-  }
-
-  // ================================================================
-  //  Strategy 3: Look for window.Store (some WA versions expose it)
-  // ================================================================
-  function strategyWindowStore() {
-    if (window.Store && window.Store.Chat) {
-      console.log(TAG, 'Strategy 3: Found window.Store directly');
-      return window.Store;
-    }
-    return null;
-  }
-
-  // ================================================================
-  //  Strategy 4: Search window properties for Store-like objects
-  // ================================================================
-  function strategyWindowSearch() {
-    try {
-      const candidates = Object.keys(window).filter((key) => {
-        try {
-          const val = window[key];
-          return (
-            val &&
-            typeof val === 'object' &&
-            val.Chat &&
-            typeof val.Chat.get === 'function'
-          );
-        } catch (_) {
-          return false;
+        if (type === 'Q10_ADAPTER_UNAVAILABLE' || type === 'Q10_STORE_FALLBACK') {
+          window.removeEventListener('message', handler);
+          window.removeEventListener('message', fallbackHandler);
+          clearTimeout(timeoutId);
+          resolve(false);
         }
-      });
+      };
 
-      if (candidates.length > 0) {
-        console.log(TAG, 'Strategy 4: Found Store-like object at window.' + candidates[0]);
-        return window[candidates[0]];
-      }
-    } catch (err) {
-      console.warn(TAG, 'strategyWindowSearch error:', err.message);
-    }
-    return null;
-  }
-
-  // ================================================================
-  //  Strategy 5: Use require('WAWebCollections') if available
-  // ================================================================
-  function strategyRequire() {
-    try {
-      if (typeof window.require === 'function') {
-        const collections = window.require('WAWebCollections');
-        if (collections && collections.ChatCollection) {
-          console.log(TAG, 'Strategy 5: Found via WAWebCollections require');
-          return {
-            Chat: collections.ChatCollection,
-            Contact: collections.ContactCollection || null,
-            Msg: collections.MsgCollection || null,
-          };
+      var fallbackHandler = function(event) {
+        if (event.source !== window) return;
+        if (event.data && event.data.type === 'Q10_STORE_FALLBACK') {
+          window.removeEventListener('message', handler);
+          window.removeEventListener('message', fallbackHandler);
+          clearTimeout(timeoutId);
+          resolve(false);
         }
-      }
-    } catch (_) { /* not available */ }
-    return null;
+      };
+
+      window.addEventListener('message', handler);
+      window.addEventListener('message', fallbackHandler);
+
+      var timeoutId = setTimeout(function() {
+        window.removeEventListener('message', handler);
+        window.removeEventListener('message', fallbackHandler);
+        resolve(false);
+      }, ADAPTER_INIT_TIMEOUT);
+    });
   }
 
-  // ================================================================
-  //  Master loader — tries all strategies with polling
-  // ================================================================
-  async function loadStore() {
-    let attempt = 0;
-
-    while (attempt < MAX_RETRIES) {
-      attempt++;
-
-      // Quick strategies first
-      let store = strategyWindowStore();
-      if (store) return store;
-
-      store = strategyRequire();
-      if (store) return store;
-
-      store = strategyWindowSearch();
-      if (store) return store;
-
-      // Webpack search (heavier)
-      store = searchModulesInWebpack();
-      if (store) return store;
-
-      if (attempt === 1) {
-        console.log(TAG, 'Store not available yet, polling...');
-        // Try webpack intercept in parallel (only once)
-        strategyWebpackIntercept().then((s) => {
-          if (s && !window.Q10Store) {
-            window.Q10Store = s;
-            announceStoreReady(s);
-          }
-        });
-      }
-
-      await sleep(RETRY_INTERVAL);
-    }
-
-    return null;
-  }
-
-  function sleep(ms) {
-    return new Promise((r) => setTimeout(r, ms));
-  }
-
-  function announceStoreReady(store) {
-    console.log(TAG, '✅ Store loaded! Available collections:', Object.keys(store).join(', '));
-    window.postMessage({ type: 'Q10_STORE_READY', collections: Object.keys(store) }, '*');
-  }
-
-  // ================================================================
+  // ──────────────────────────────────────────────────────────────
   //  Init
-  // ================================================================
-  (async function init() {
+  // ──────────────────────────────────────────────────────────────
+  async function init() {
     console.log(TAG, 'Store loader starting...');
 
-    const store = await loadStore();
+    await loadAdapter();
+    var available = await waitForAdapterSignal();
 
-    if (store) {
-      window.Q10Store = store;
-      announceStoreReady(store);
+    if (available) {
+      console.log(TAG, 'Q10StoreAdapter ready.');
     } else {
-      console.warn(TAG, '⚠️ Could not find WhatsApp Store after', MAX_RETRIES, 'attempts.');
-      console.warn(TAG, 'Falling back to DOM-based detection.');
-      window.postMessage({ type: 'Q10_STORE_FALLBACK' }, '*');
+      console.warn(TAG, 'Q10StoreAdapter unavailable — DOM fallback will be used.');
     }
-  })();
+  }
+
+  init();
 })();

--- a/inject/store-adapter.js
+++ b/inject/store-adapter.js
@@ -1,0 +1,434 @@
+/* ============================================================
+   Q10 CRM — WhatsApp Store Adapter
+   
+   Abstraction layer over WhatsApp Web's internal undocumented
+   Store APIs (window.Store, webpack modules, etc.).
+   
+   This module provides:
+   - A clean, documented interface to Store functionality
+   - Graceful degradation when Store is unavailable
+   - Detection of Store API breakage after WhatsApp updates
+   - Multiple strategies to locate the Store
+   
+   WHY THIS EXISTS:
+   WhatsApp Web uses internal JavaScript APIs that are NOT part
+   of their public documentation. These live in the global
+   `window.Store` object and related webpack modules. Meta can
+   change these at any time without notice, breaking the plugin.
+   
+   DOCUMENTED Store METHODS USED:
+   ============================================================
+   
+   Collection: window.Store.Chat (ChatCollection)
+   -----------------------------------------------
+   .get(chatId: string): ChatModel | null
+     → Retrieve a specific chat by its ID
+     → Used for: looking up rich chat data from DOM-detected ID
+   
+   .getActive(): ChatModel | null
+     → Get the currently active/selected chat
+     → Used for: detecting which chat is open
+   
+   .getModelsArray(): ChatModel[]
+     → Get all chat models as an array
+     → Used for: finding the active chat by .active flag
+   
+   .on(event: string, callback: Function): void
+     → Subscribe to collection change events
+     → Events used: 'change:active' — fires when active chat changes
+     → Used for: real-time chat switch detection
+   
+   Collection: window.Store.Contact (ContactCollection)
+   ------------------------------------------------------
+   .get(contactId: string): ContactModel | null
+     → Retrieve a contact by ID
+     → Used for: getting pushname/profile pic for a chat
+   
+   .getModelsArray(): ContactModel[]
+     → Get all contacts
+   
+   Collection: window.Store.Msg (MsgCollection)
+   --------------------------------------------
+   .get(msgId: string): MsgModel | null
+     → Retrieve a specific message
+   
+   Object: window.Store.Conn (ConnService)
+   ---------------------------------------
+   .wid: string
+     → The current user's WhatsApp ID (phone number)
+   
+   Object: window.Store.Cmd
+   ------------------------
+   .openChatBottom(chatId: string): void
+     → Programmatically open chat panel
+   
+   ChatModel properties used:
+   --------------------------
+   .id._serialized: string  — Full chat ID (e.g. "5519988145438@c.us")
+   .id.toString(): string   — Same as above
+   .name: string | null     — Display name
+   .formattedTitle: string  — Formatted name
+   .active: boolean         — Whether chat is currently selected
+   .isActive: boolean       — Alternative active flag
+   .contact: ContactModel   — Associated contact object
+   .contact.pushname: string — WhatsApp-defined push name
+   .contact.formattedName: string — Formatted contact name
+   .contact.profilePicThumb.eurl: string — Profile pic URL
+   
+   ContactModel properties used:
+   -----------------------------
+   .id._serialized: string — Contact ID
+   .pushname: string | null — WhatsApp push name
+   .formattedName: string — Formatted display name
+   .name: string — Given name
+   .shortName: string | null — Short name
+   .profilePicThumb.eurl: string | null — Profile pic URL
+   
+   ============================================================
+   GRACEFUL DEGRADATION:
+   If Store is unavailable (WhatsApp updated, not loaded yet, etc.)
+   the adapter returns null for lookups and the caller falls back
+   to DOM-based detection. No errors are thrown.
+   
+   BREAKAGE DETECTION:
+   After initial successful load, any subsequent error when calling
+   Store methods sets a "degraded" flag. After 3 consecutive errors,
+   the Store is marked as "broken" and all methods return null.
+   A 'Q10_STORE_BROKEN' message is posted so the inject script knows
+   to rely entirely on DOM fallback.
+   ============================================================ */
+
+(function (global) {
+  'use strict';
+
+  const TAG = '[Q10 StoreAdapter]';
+  var CONSECUTIVE_ERROR_THRESHOLD = 3;
+
+  // ──────────────────────────────────────────────────────────────
+  //  State
+  // ──────────────────────────────────────────────────────────────
+  var storeRef = null;  // Raw store reference, null = unresolved, 'broken' = failed
+  var errorCount = 0;
+  var degraded = false;
+  var broken = false;
+
+  // ──────────────────────────────────────────────────────────────
+  //  Module detection predicates
+  // ──────────────────────────────────────────────────────────────
+  var STORE_MODULE_CHECKS = {
+    Chat:    function(m) { return m.Chat && m.Chat.get && (m.Chat.getModelsArray || m.Chat.getArray); },
+    Contact: function(m) { return m.Contact && m.Contact.get && m.Contact.getModelsArray; },
+    Msg:     function(m) { return m.Msg && m.Msg.get; },
+    Conn:    function(m) { return m.Conn && m.Conn.wid; },
+    Cmd:     function(m) { return m.Cmd && m.Cmd.openChatBottom; }
+  };
+
+  // ──────────────────────────────────────────────────────────────
+  //  Error tracking
+  // ──────────────────────────────────────────────────────────────
+  function trackError(err) {
+    if (broken || degraded) return;
+    errorCount++;
+    if (errorCount >= CONSECUTIVE_ERROR_THRESHOLD) {
+      broken = true;
+      console.error(TAG, 'Store marked BROKEN after', errorCount, 'consecutive errors:', err ? err.message || err : '');
+      try {
+        global.postMessage({ type: 'Q10_STORE_BROKEN', errorCount: errorCount }, '*');
+      } catch (_) { /* ignore */ }
+    }
+  }
+
+  function trackSuccess() {
+    errorCount = 0;
+  }
+
+  // ──────────────────────────────────────────────────────────────
+  //  Strategy 1: Direct window.Store
+  // ──────────────────────────────────────────────────────────────
+  function strategyDirectWindowStore() {
+    try {
+      if (global.Store && global.Store.Chat && global.Store.Chat.get) {
+        console.log(TAG, 'Strategy 1 (direct window.Store): Store found');
+        return global.Store;
+      }
+    } catch (_) { /* not available */ }
+    return null;
+  }
+
+  // ──────────────────────────────────────────────────────────────
+  //  Strategy 2: webpackChunkwhatsapp_web_client module search
+  // ──────────────────────────────────────────────────────────────
+  function searchWebpackModules() {
+    try {
+      var chunk = global.webpackChunkwhatsapp_web_client;
+      if (!chunk || chunk.length === 0) return null;
+
+      var moduleId = '__q10_adapter_probe_' + Date.now();
+      var modules = null;
+
+      chunk.push([
+        [moduleId],
+        {},
+        function (require) {
+          modules = require;
+        }
+      ]);
+
+      if (!modules || !modules.m) return null;
+
+      var found = {};
+
+      var keys = Object.keys(modules.m);
+      for (var i = 0; i < keys.length; i++) {
+        try {
+          var mod = modules(keys[i]);
+          if (!mod || typeof mod !== 'object') continue;
+
+          var name;
+          for (name in STORE_MODULE_CHECKS) {
+            if (!found[name]) {
+              try {
+                if (STORE_MODULE_CHECKS[name](mod)) {
+                  found[name] = mod[name];
+                } else if (mod.default && STORE_MODULE_CHECKS[name](mod.default)) {
+                  found[name] = mod.default[name];
+                }
+              } catch (_) { /* skip */ }
+            }
+          }
+        } catch (_) { /* skip */ }
+      }
+
+      if (found.Chat) {
+        console.log(TAG, 'Strategy 2 (webpack search): found modules:', Object.keys(found).join(', '));
+        return found;
+      }
+    } catch (err) {
+      console.warn(TAG, 'Strategy 2 error:', err.message);
+    }
+    return null;
+  }
+
+  // ──────────────────────────────────────────────────────────────
+  //  Strategy 3: window.require('WAWebCollections')
+  // ──────────────────────────────────────────────────────────────
+  function strategyRequireCollections() {
+    try {
+      if (typeof global.require === 'function') {
+        var collections = global.require('WAWebCollections');
+        if (collections && collections.ChatCollection) {
+          console.log(TAG, 'Strategy 3 (WAWebCollections require): found collections');
+          return {
+            Chat:    collections.ChatCollection,
+            Contact: collections.ContactCollection || null,
+            Msg:     collections.MsgCollection || null
+          };
+        }
+      }
+    } catch (_) { /* not available */ }
+    return null;
+  }
+
+  // ──────────────────────────────────────────────────────────────
+  //  Strategy 4: Scan window properties for Store-like objects
+  // ──────────────────────────────────────────────────────────────
+  function strategyWindowSearch() {
+    try {
+      var candidates = Object.keys(global).filter(function(key) {
+        try {
+          var val = global[key];
+          return (
+            val &&
+            typeof val === 'object' &&
+            val.Chat &&
+            typeof val.Chat.get === 'function'
+          );
+        } catch (_) {
+          return false;
+        }
+      });
+
+      if (candidates.length > 0) {
+        console.log(TAG, 'Strategy 4 (window scan): found Store-like at window.' + candidates[0]);
+        return global[candidates[0]];
+      }
+    } catch (err) {
+      console.warn(TAG, 'Strategy 4 error:', err.message);
+    }
+    return null;
+  }
+
+  // ──────────────────────────────────────────────────────────────
+  //  Public init — resolve the Store
+  // ──────────────────────────────────────────────────────────────
+  function resolveStore() {
+    if (storeRef) return storeRef !== 'broken';
+
+    var strategies = [
+      strategyDirectWindowStore,
+      strategyRequireCollections,
+      strategyWindowSearch,
+      searchWebpackModules
+    ];
+
+    for (var i = 0; i < strategies.length; i++) {
+      try {
+        var result = strategies[i]();
+        if (result) {
+          storeRef = result;
+          trackSuccess();
+          console.log(TAG, 'Store resolved successfully');
+          return true;
+        }
+      } catch (err) {
+        console.warn(TAG, strategies[i].name, 'threw:', err.message);
+      }
+    }
+
+    storeRef = 'broken';
+    return false;
+  }
+
+  // ──────────────────────────────────────────────────────────────
+  //  Public API — Safe wrappers with error tracking
+  // ──────────────────────────────────────────────────────────────
+
+  function isAvailable() {
+    return storeRef && storeRef !== 'broken';
+  }
+
+  function isBroken() {
+    return broken;
+  }
+
+  function getRawStore() {
+    return isAvailable() ? storeRef : null;
+  }
+
+  function getChatById(chatId) {
+    if (!isAvailable() || broken) return null;
+    try {
+      trackSuccess();
+      return storeRef.Chat.get(chatId);
+    } catch (err) {
+      trackError(err);
+      return null;
+    }
+  }
+
+  function getActiveChat() {
+    if (!isAvailable() || broken) return null;
+    try {
+      trackSuccess();
+      if (typeof storeRef.Chat.getActive === 'function') {
+        var chat = storeRef.Chat.getActive();
+        if (chat) return chat;
+      }
+      if (typeof storeRef.Chat.getModelsArray === 'function') {
+        var chats = storeRef.Chat.getModelsArray();
+        for (var i = 0; i < chats.length; i++) {
+          if (chats[i].active || chats[i].isActive) return chats[i];
+        }
+      }
+      return null;
+    } catch (err) {
+      trackError(err);
+      return null;
+    }
+  }
+
+  function getAllChats() {
+    if (!isAvailable() || broken) return [];
+    try {
+      trackSuccess();
+      if (typeof storeRef.Chat.getModelsArray === 'function') return storeRef.Chat.getModelsArray();
+      if (typeof storeRef.Chat.getArray === 'function') return storeRef.Chat.getArray();
+      return [];
+    } catch (err) {
+      trackError(err);
+      return [];
+    }
+  }
+
+  function onActiveChatChange(callback) {
+    if (!isAvailable() || broken) return null;
+    try {
+      trackSuccess();
+      if (typeof storeRef.Chat.on === 'function') {
+        storeRef.Chat.on('change:active', callback);
+        return function() {
+          try {
+            if (typeof storeRef.Chat.off === 'function') {
+              storeRef.Chat.off('change:active', callback);
+            }
+          } catch (_) { /* ignore */ }
+        };
+      }
+    } catch (err) {
+      trackError(err);
+    }
+    return null;
+  }
+
+  function getContactById(contactId) {
+    if (!isAvailable() || broken) return null;
+    if (!storeRef.Contact) return null;
+    try {
+      trackSuccess();
+      return storeRef.Contact.get(contactId);
+    } catch (err) {
+      trackError(err);
+      return null;
+    }
+  }
+
+  function getCurrentWid() {
+    if (!isAvailable() || broken) return null;
+    try {
+      trackSuccess();
+      return storeRef.Conn && storeRef.Conn.wid ? storeRef.Conn.wid : null;
+    } catch (err) {
+      trackError(err);
+      return null;
+    }
+  }
+
+  // ──────────────────────────────────────────────────────────────
+  //  Bootstrap
+  // ──────────────────────────────────────────────────────────────
+  function bootstrap() {
+    var success = resolveStore();
+
+    if (success) {
+      console.log(TAG, 'Store resolved — Adapter ready');
+      try {
+        global.postMessage({ type: 'Q10_ADAPTER_READY', collections: Object.keys(storeRef).join(', ') }, '*');
+      } catch (_) { /* ignore */ }
+    } else {
+      console.warn(TAG, 'Store could not be resolved — Adapter unavailable');
+      try {
+        global.postMessage({ type: 'Q10_ADAPTER_UNAVAILABLE' }, '*');
+      } catch (_) { /* ignore */ }
+    }
+  }
+
+  // ──────────────────────────────────────────────────────────────
+  //  Expose public API
+  // ──────────────────────────────────────────────────────────────
+  global.Q10StoreAdapter = {
+    resolveStore: resolveStore,
+    isAvailable: isAvailable,
+    isBroken: isBroken,
+    getRawStore: getRawStore,
+    getChatById: getChatById,
+    getActiveChat: getActiveChat,
+    getAllChats: getAllChats,
+    onActiveChatChange: onActiveChatChange,
+    getContactById: getContactById,
+    getCurrentWid: getCurrentWid
+  };
+
+  // Auto-bootstrap
+  bootstrap();
+
+})(typeof global !== 'undefined' ? global : window);

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Q10 CRM para WhatsApp Web",
   "version": "3.4.0",
-  "description": "CRM Q10 integrado con WhatsApp Web — consulta datos de estudiantes, leads y oportunidades directamente desde WhatsApp.",
+  "description": "CRM Q10 integrado con WhatsApp Web \u2014 consulta datos de estudiantes, leads y oportunidades directamente desde WhatsApp.",
   "permissions": [
     "storage",
     "activeTab",
@@ -57,7 +57,8 @@
         "icons/*",
         "sidepanel/*",
         "inject/inject.js",
-        "inject/loader.js"
+        "inject/loader.js",
+        "inject/store-adapter.js"
       ],
       "matches": [
         "https://web.whatsapp.com/*"


### PR DESCRIPTION
## Resumo

Adiciona camada de abstração `store-adapter.js` para as APIs internas do WhatsApp (window.Store) com degradação graciosa.


## Mudanças

- `inject/store-adapter.js`: novo — expõe API limpa (getChatById, getActiveChat, getAllChats, etc) com fallback DOM
- `inject/loader.js`: refatorado para delegar ao adapter
- `inject/inject.js`: agora usa `Q10StoreAdapter` em vez de chamar window.Q10Store diretamente
- Detecção de Store quebrado após 3 falhas → dispara evento Q10_STORE_BROKEN

Fixes diogenesmendes01/q10-whatsapp-plugin#14
