### PR TITLE
feat: batch leads import — extract WhatsApp contacts to CSV and import to Q10

### DIFF
--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -464,16 +464,18 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     case 'batchExtractComplete':
       // Content script → service worker → sidepanel (broadcast)
       // Store in session so sidepanel can read on connect
-      chrome.storage.session.set({
-        batchExtractStatus: {
-          action: msg.action,
-          count: msg.count || 0,
-          ok: msg.ok,
-          data: msg.data || null,
-          error: msg.error || null,
-          ts: Date.now()
-        }
-      });
+      try {
+        chrome.storage.session.set({
+          batchExtractStatus: {
+            action: msg.action,
+            count: msg.count || 0,
+            ok: msg.ok,
+            data: msg.data || null,
+            error: msg.error || null,
+            ts: Date.now()
+          }
+        });
+      } catch (_) { /* chrome.storage.session unavailable (Chrome < 102) */ }
       sendResponse({ ok: true });
       return false;
 

--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -445,7 +445,9 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     case 'batchExtractStop':
       (async () => {
         try {
-          const tabs = await chrome.tabs.query({ url: 'https://web.whatsapp.com/*' });
+          let tabs = await chrome.tabs.query({ url: 'https://web.whatsapp.com/*', active: true, currentWindow: true });
+          if (!tabs.length) tabs = await chrome.tabs.query({ url: 'https://web.whatsapp.com/*', active: true });
+          if (!tabs.length) tabs = await chrome.tabs.query({ url: 'https://web.whatsapp.com/*' });
           if (!tabs.length) {
             sendResponse({ ok: false, error: 'WhatsApp Web não encontrado' });
             return;
@@ -491,9 +493,10 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
             const lastName = nameParts.slice(1).join(' ') || 'WhatsApp';
             const phone = (c.phone || '').replace(/\D/g, '');
             const body = {
+              Consecutivo_oportunidad: 0,
               Nombres: firstName,
               Apellidos: lastName,
-              Detalle: [{ Tipo: 'Celular', Valor: phone }]
+              Detalle: [{ Tipo_detalle: 'Celular', Descripcion: phone }]
             };
             await apiPost('/contactos', body);
             results.push({ phone, ok: true });
@@ -503,6 +506,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         }
         const ok = results.filter(r => r.ok).length;
         const fail = results.filter(r => !r.ok).length;
+        if (ok > 0) cache.clear();
         return { results, summary: { ok, fail } };
       })());
 

--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -440,6 +440,70 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       sendResponse({ ok: true });
       return false;
 
+    // ── Batch leads: forward start/stop to content script ──────────────
+    case 'batchExtractStart':
+    case 'batchExtractStop':
+      (async () => {
+        try {
+          const tabs = await chrome.tabs.query({ url: 'https://web.whatsapp.com/*' });
+          if (!tabs.length) {
+            sendResponse({ ok: false, error: 'WhatsApp Web não encontrado' });
+            return;
+          }
+          chrome.tabs.sendMessage(tabs[0].id, { action: msg.action, cutoffMs: msg.cutoffMs || null }, (resp) => {
+            sendResponse(resp || { ok: true });
+          });
+        } catch (e) {
+          sendResponse({ ok: false, error: e.message });
+        }
+      })();
+      return true;
+
+    // ── Batch leads: relay progress/complete from content script to sidepanel ──
+    case 'batchExtractProgress':
+    case 'batchExtractComplete':
+      // Content script → service worker → sidepanel (broadcast)
+      // Store in session so sidepanel can read on connect
+      chrome.storage.session.set({
+        batchExtractStatus: {
+          action: msg.action,
+          count: msg.count || 0,
+          ok: msg.ok,
+          data: msg.data || null,
+          error: msg.error || null,
+          ts: Date.now()
+        }
+      });
+      sendResponse({ ok: true });
+      return false;
+
+    // ── Batch leads: import CSV contacts to Q10 ──────────────────────────
+    case 'batchImportContacts':
+      return handle((async () => {
+        const contacts = msg.contacts || [];
+        const results = [];
+        for (const c of contacts) {
+          try {
+            const nameParts = (c.name || '').trim().split(/\s+/);
+            const firstName = nameParts[0] || 'Contato';
+            const lastName = nameParts.slice(1).join(' ') || 'WhatsApp';
+            const phone = (c.phone || '').replace(/\D/g, '');
+            const body = {
+              Nombres: firstName,
+              Apellidos: lastName,
+              Detalle: [{ Tipo: 'Celular', Valor: phone }]
+            };
+            await apiPost('/contactos', body);
+            results.push({ phone, ok: true });
+          } catch (e) {
+            results.push({ phone: c.phone, ok: false, error: e.message });
+          }
+        }
+        const ok = results.filter(r => r.ok).length;
+        const fail = results.filter(r => !r.ok).length;
+        return { results, summary: { ok, fail } };
+      })());
+
     default:
       sendResponse({ ok: false, error: `Unknown action: ${msg.action}` });
       return false;

--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -453,6 +453,15 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
             return;
           }
           chrome.tabs.sendMessage(tabs[0].id, { action: msg.action, cutoffMs: msg.cutoffMs || null }, (resp) => {
+            // If the content script isn't listening (page reloading, plugin just installed,
+            // etc.) sendMessage delivers no response and sets runtime.lastError. Reading it
+            // here both surfaces the failure to the sidepanel and silences Chrome's
+            // "Unchecked runtime.lastError" warning.
+            const err = chrome.runtime.lastError;
+            if (err) {
+              sendResponse({ ok: false, error: 'Não foi possível falar com a aba do WhatsApp Web. Recarregue a página e tente novamente.' });
+              return;
+            }
             sendResponse(resp || { ok: true });
           });
         } catch (e) {

--- a/content/content.js
+++ b/content/content.js
@@ -355,7 +355,7 @@
       const dataId = item.getAttribute('data-id') || '';
       // Skip groups and broadcasts
       if (!dataId.includes('@c.us')) return;
-      const phoneMatch = dataId.match(/(\d{7,15})@c\.us/);
+      const phoneMatch = dataId.match(/(\d{10,15})@c\.us/);
       if (!phoneMatch) return;
       const phone = phoneMatch[1];
 

--- a/content/content.js
+++ b/content/content.js
@@ -339,6 +339,97 @@
     return messages;
   }
 
+  // ================================================================
+  //  BATCH CONTACTS EXTRACTION (scroll chat list)
+  // ================================================================
+  let batchExtracting = false;
+
+  function extractVisibleChatContacts() {
+    const contacts = new Map();
+    // WhatsApp Web stores each chat in a list item with data-id="PHONE@c.us"
+    const pane = document.querySelector('#pane-side');
+    if (!pane) return contacts;
+
+    const items = pane.querySelectorAll('[data-id]');
+    items.forEach(item => {
+      const dataId = item.getAttribute('data-id') || '';
+      // Skip groups and broadcasts
+      if (!dataId.includes('@c.us')) return;
+      const phoneMatch = dataId.match(/(\d{7,15})@c\.us/);
+      if (!phoneMatch) return;
+      const phone = phoneMatch[1];
+
+      // Try multiple selectors for the contact name
+      const nameEl =
+        item.querySelector('[data-testid="cell-frame-title"] span') ||
+        item.querySelector('span[dir="auto"]') ||
+        item.querySelector('span[title]');
+      const rawName = (nameEl?.textContent || nameEl?.getAttribute('title') || '').trim();
+      // If the "name" is just digits it's actually the phone number — store empty
+      const name = /^[\d\s\+\-\(\)]+$/.test(rawName) ? '' : rawName;
+
+      contacts.set(phone, { phone, name });
+    });
+    return contacts;
+  }
+
+  async function runBatchExtraction(cutoffMs) {
+    batchExtracting = true;
+    const allContacts = new Map();
+    const pane = document.querySelector('#pane-side');
+
+    if (!pane) {
+      chrome.runtime.sendMessage({ action: 'batchExtractComplete', ok: false, error: 'Painel de conversas não encontrado. Abra o WhatsApp Web.' });
+      return;
+    }
+
+    let noNewCount = 0;
+    let lastCount = 0;
+
+    while (batchExtracting) {
+      const batch = extractVisibleChatContacts();
+      batch.forEach((v, k) => allContacts.set(k, v));
+
+      const newCount = allContacts.size;
+      chrome.runtime.sendMessage({ action: 'batchExtractProgress', count: newCount });
+
+      // Stop if cutoff date reached — check last visible chat item timestamp
+      if (cutoffMs) {
+        const timeEls = pane.querySelectorAll('[data-testid="cell-frame-secondary-detail"] span');
+        const lastTimeEl = timeEls[timeEls.length - 1];
+        if (lastTimeEl) {
+          const txt = (lastTimeEl.textContent || '').trim();
+          // WhatsApp shows absolute dates like "12/05/24" for old chats
+          const dateMatch = txt.match(/(\d{1,2})\/(\d{1,2})\/(\d{2,4})/);
+          if (dateMatch) {
+            const [, d, m, y] = dateMatch;
+            const fullYear = y.length === 2 ? 2000 + parseInt(y) : parseInt(y);
+            const chatDate = new Date(fullYear, parseInt(m) - 1, parseInt(d)).getTime();
+            if (chatDate < cutoffMs) {
+              batchExtracting = false;
+              break;
+            }
+          }
+        }
+      }
+
+      if (newCount === lastCount) {
+        noNewCount++;
+        if (noNewCount >= 4) break; // 4 scrolls with no new = reached end
+      } else {
+        noNewCount = 0;
+      }
+      lastCount = newCount;
+
+      pane.scrollTop += 700;
+      await new Promise(r => setTimeout(r, 700));
+    }
+
+    batchExtracting = false;
+    const result = Array.from(allContacts.values());
+    chrome.runtime.sendMessage({ action: 'batchExtractComplete', ok: true, data: result });
+  }
+
   // Listen for export request from sidepanel via service worker
   chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     if (msg.action === 'exportConversation') {
@@ -348,6 +439,20 @@
       } catch (e) {
         sendResponse({ ok: false, error: e.message });
       }
+      return true;
+    }
+
+    if (msg.action === 'batchExtractStart') {
+      if (batchExtracting) { sendResponse({ ok: true }); return true; }
+      const cutoffMs = msg.cutoffMs || null;
+      runBatchExtraction(cutoffMs);
+      sendResponse({ ok: true });
+      return true;
+    }
+
+    if (msg.action === 'batchExtractStop') {
+      batchExtracting = false;
+      sendResponse({ ok: true });
       return true;
     }
   });

--- a/content/content.js
+++ b/content/content.js
@@ -343,6 +343,10 @@
   //  BATCH CONTACTS EXTRACTION (scroll chat list)
   // ================================================================
   let batchExtracting = false;
+  // Bumped on every start. The running loop captures its own value and exits
+  // silently if it gets superseded — prevents a stop→start race where the old
+  // loop, still asleep in setTimeout, would resume and run alongside the new one.
+  let batchGen = 0;
 
   function extractVisibleChatContacts() {
     const contacts = new Map();
@@ -374,6 +378,7 @@
   }
 
   async function runBatchExtraction(cutoffMs) {
+    const myGen = ++batchGen;
     batchExtracting = true;
     const allContacts = new Map();
     const pane = document.querySelector('#pane-side');
@@ -386,7 +391,7 @@
     let noNewCount = 0;
     let lastCount = 0;
 
-    while (batchExtracting) {
+    while (batchExtracting && myGen === batchGen) {
       const batch = extractVisibleChatContacts();
       batch.forEach((v, k) => allContacts.set(k, v));
 
@@ -424,6 +429,9 @@
       pane.scrollTop += 700;
       await new Promise(r => setTimeout(r, 700));
     }
+
+    // Superseded by a newer run — exit silently; the new run will send complete.
+    if (myGen !== batchGen) return;
 
     batchExtracting = false;
     const result = Array.from(allContacts.values());

--- a/sidepanel/modules/batchLeads.js
+++ b/sidepanel/modules/batchLeads.js
@@ -4,6 +4,21 @@
    and imports a CSV file → Q10 /contactos (batch)
    ============================================================ */
 
+const CSV_MAX_BYTES = 5 * 1024 * 1024; // 5 MB limit for uploaded CSV
+
+// ================================================================
+//  chrome.storage.session compatibility (Chrome 102+)
+// ================================================================
+const _sessionFallback = {};
+
+function _sessionGet(keys, cb) {
+  if (chrome.storage?.session?.get) {
+    chrome.storage.session.get(keys, cb);
+  } else {
+    cb(Object.fromEntries(keys.map(k => [k, _sessionFallback[k] ?? undefined])));
+  }
+}
+
 // ================================================================
 //  RENDER
 // ================================================================
@@ -57,6 +72,9 @@ export function renderBatchLeads() {
           </div>
         </div>
 
+        <div id="bl-extract-error"
+          style="display:none;margin-top:8px;font-size:12px;color:#EF4444;font-weight:500;"></div>
+
         <div id="bl-result" style="display:none;margin-top:10px;">
           <div style="font-size:12px;color:#059669;font-weight:500;" id="bl-result-label"></div>
           <button id="bl-csv-btn"
@@ -73,13 +91,16 @@ export function renderBatchLeads() {
           2. Importar CSV para Q10
         </div>
         <div style="font-size:11px;color:#9CA3AF;margin-bottom:8px;">
-          Colunas esperadas: <code>telefone,nome</code>
+          Colunas esperadas: <code>telefone,nome</code> &nbsp;·&nbsp; Máx. 5 MB
         </div>
         <label style="display:block;border:1.5px dashed #D1D5DB;border-radius:8px;padding:12px;
                       text-align:center;cursor:pointer;font-size:12px;color:#6B7280;">
-          <input type="file" id="bl-csv-input" accept=".csv" style="display:none;">
+          <input type="file" id="bl-csv-input" accept=".csv,text/csv" style="display:none;">
           &#128194; Selecionar arquivo CSV
         </label>
+
+        <div id="bl-csv-error"
+          style="display:none;margin-top:8px;font-size:12px;color:#EF4444;font-weight:500;"></div>
 
         <div id="bl-import-preview" style="display:none;margin-top:10px;">
           <div style="font-size:12px;color:#374151;font-weight:500;margin-bottom:6px;"
@@ -131,7 +152,6 @@ let _extractedContacts = [];
 let _importContacts = [];
 
 function bindBatchLeadsEvents() {
-  // Period selector
   document.getElementById('bl-period-btns').addEventListener('click', e => {
     const btn = e.target.closest('.bl-period');
     if (!btn) return;
@@ -147,22 +167,12 @@ function bindBatchLeadsEvents() {
     btn.style.color = '#0369A1';
   });
 
-  // Extract button
   document.getElementById('bl-extract-btn').addEventListener('click', startExtraction);
-
-  // Stop button
   document.getElementById('bl-stop-btn').addEventListener('click', stopExtraction);
-
-  // CSV download button (set later when data is ready)
   document.getElementById('bl-csv-btn').addEventListener('click', downloadCSV);
-
-  // CSV file input
   document.getElementById('bl-csv-input').addEventListener('change', onCSVFileSelected);
-
-  // Import button
   document.getElementById('bl-import-btn').addEventListener('click', startImport);
 
-  // Start polling for extraction progress
   _startProgressPolling();
 }
 
@@ -170,34 +180,34 @@ function bindBatchLeadsEvents() {
 //  EXTRACTION
 // ================================================================
 function getSelectedPeriod() {
-  const active = document.querySelector('.bl-period-active');
-  return active?.dataset?.period || 'Tudo';
+  return document.querySelector('.bl-period-active')?.dataset?.period || 'Tudo';
 }
 
 function periodToCutoffMs(period) {
-  const now = Date.now();
   const map = { '3m': 90, '6m': 180, '1a': 365 };
   const days = map[period];
-  if (!days) return null; // "Tudo" = no cutoff
-  return now - days * 24 * 60 * 60 * 1000;
+  return days ? Date.now() - days * 24 * 60 * 60 * 1000 : null;
 }
 
 function startExtraction() {
-  const period = getSelectedPeriod();
-  const cutoffMs = periodToCutoffMs(period);
-
   _extractedContacts = [];
 
   document.getElementById('bl-extract-btn').disabled = true;
   document.getElementById('bl-extract-btn').style.opacity = '0.6';
   document.getElementById('bl-progress').style.display = 'block';
   document.getElementById('bl-result').style.display = 'none';
+  document.getElementById('bl-extract-error').style.display = 'none';
   document.getElementById('bl-progress-label').textContent = 'Iniciando...';
+  // Reset bar to animated state
+  const bar = document.getElementById('bl-progress-bar');
+  bar.style.background = '#0EA5E9';
+  bar.style.animation = 'bl-pulse 1.2s ease-in-out infinite';
+  document.getElementById('bl-stop-btn').style.display = '';
 
+  const cutoffMs = periodToCutoffMs(getSelectedPeriod());
   chrome.runtime.sendMessage({ action: 'batchExtractStart', cutoffMs }, (resp) => {
     if (resp && !resp.ok) {
-      stopExtraction();
-      document.getElementById('bl-progress-label').textContent = resp.error || 'Erro ao iniciar';
+      _showExtractError(resp.error || 'Erro ao iniciar extração');
     }
   });
 }
@@ -209,19 +219,27 @@ function stopExtraction() {
   document.getElementById('bl-progress').style.display = 'none';
 }
 
+function _showExtractError(msg) {
+  document.getElementById('bl-extract-btn').disabled = false;
+  document.getElementById('bl-extract-btn').style.opacity = '1';
+  document.getElementById('bl-progress').style.display = 'none';
+  const err = document.getElementById('bl-extract-error');
+  err.textContent = msg;
+  err.style.display = 'block';
+}
+
 let _pollInterval = null;
 let _lastStatusTs = 0;
 
 function _startProgressPolling() {
   if (_pollInterval) clearInterval(_pollInterval);
   _pollInterval = setInterval(() => {
-    // Auto-stop if the batch leads view was replaced by another view
     if (!document.getElementById('bl-progress')) {
       clearInterval(_pollInterval);
       _pollInterval = null;
       return;
     }
-    chrome.storage.session.get(['batchExtractStatus'], result => {
+    _sessionGet(['batchExtractStatus'], result => {
       const s = result.batchExtractStatus;
       if (!s || s.ts === _lastStatusTs) return;
       _lastStatusTs = s.ts;
@@ -233,6 +251,7 @@ function _startProgressPolling() {
 
       if (s.action === 'batchExtractComplete') {
         clearInterval(_pollInterval);
+        _pollInterval = null;
         document.getElementById('bl-extract-btn').disabled = false;
         document.getElementById('bl-extract-btn').style.opacity = '1';
         document.getElementById('bl-progress').style.display = 'none';
@@ -243,12 +262,7 @@ function _startProgressPolling() {
           document.getElementById('bl-result-label').textContent =
             `✓ ${s.data.length} contatos extraídos`;
         } else {
-          document.getElementById('bl-progress').style.display = 'block';
-          document.getElementById('bl-progress-label').textContent =
-            s.error || 'Extração falhou';
-          document.getElementById('bl-stop-btn').style.display = 'none';
-          document.getElementById('bl-progress-bar').style.animationName = 'none';
-          document.getElementById('bl-progress-bar').style.background = '#EF4444';
+          _showExtractError(s.error || 'Extração falhou');
         }
       }
     });
@@ -274,27 +288,26 @@ function downloadCSV() {
 }
 
 // ================================================================
-//  CSV IMPORT
+//  HELPERS
 // ================================================================
 function _escHtml(s) {
   return String(s || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
 }
 
 function _parseCSVLine(line) {
-  // Handles RFC 4180: fields may be quoted, commas inside quotes are preserved
   const fields = [];
   let i = 0;
   while (i < line.length) {
     if (line[i] === '"') {
       let val = '';
-      i++; // skip opening quote
+      i++;
       while (i < line.length) {
         if (line[i] === '"' && line[i + 1] === '"') { val += '"'; i += 2; }
         else if (line[i] === '"') { i++; break; }
         else { val += line[i++]; }
       }
       fields.push(val);
-      if (line[i] === ',') i++; // skip comma after field
+      if (line[i] === ',') i++;
     } else {
       const end = line.indexOf(',', i);
       if (end === -1) { fields.push(line.slice(i)); break; }
@@ -305,25 +318,58 @@ function _parseCSVLine(line) {
   return fields;
 }
 
+// ================================================================
+//  CSV IMPORT
+// ================================================================
 function parseCSV(text) {
   const lines = text.trim().split(/\r?\n/);
   if (lines.length < 2) return [];
   const firstLine = lines[0].toLowerCase();
   const startIdx = (firstLine.includes('telefone') || firstLine.includes('phone')) ? 1 : 0;
+
+  const seen = new Set();
   return lines.slice(startIdx).map(line => {
     const fields = _parseCSVLine(line);
     const phone = (fields[0] || '').trim().replace(/\D/g, '');
     const name = (fields[1] || '').trim();
     return { phone, name };
-  }).filter(c => c.phone.length >= 7);
+  }).filter(c => {
+    if (c.phone.length < 10) return false; // require at least 10 digits
+    if (seen.has(c.phone)) return false;   // dedup within file
+    seen.add(c.phone);
+    return true;
+  });
+}
+
+function _showCSVError(msg) {
+  const err = document.getElementById('bl-csv-error');
+  err.textContent = msg;
+  err.style.display = 'block';
+  document.getElementById('bl-import-preview').style.display = 'none';
 }
 
 function onCSVFileSelected(e) {
   const file = e.target.files[0];
   if (!file) return;
+
+  document.getElementById('bl-csv-error').style.display = 'none';
+
+  if (!file.name.toLowerCase().endsWith('.csv') && file.type !== 'text/csv') {
+    _showCSVError('Arquivo inválido. Selecione um arquivo .csv');
+    return;
+  }
+  if (file.size > CSV_MAX_BYTES) {
+    _showCSVError(`Arquivo muito grande (${(file.size/1024/1024).toFixed(1)} MB). Máx. 5 MB.`);
+    return;
+  }
+
   const reader = new FileReader();
   reader.onload = ev => {
     _importContacts = parseCSV(ev.target.result);
+    if (!_importContacts.length) {
+      _showCSVError('Nenhum contato válido encontrado. Verifique o formato: telefone,nome');
+      return;
+    }
     showImportPreview();
   };
   reader.readAsText(file, 'UTF-8');
@@ -348,6 +394,17 @@ function showImportPreview() {
   preview.style.display = 'block';
 }
 
+async function _sendChunkWithRetry(chunk, maxRetries = 2) {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const resp = await new Promise(resolve => {
+      chrome.runtime.sendMessage({ action: 'batchImportContacts', contacts: chunk }, resolve);
+    });
+    if (resp && resp.ok && resp.data) return resp.data;
+    if (attempt < maxRetries) await new Promise(r => setTimeout(r, 1000 * (attempt + 1)));
+  }
+  return { summary: { ok: 0, fail: chunk.length } };
+}
+
 async function startImport() {
   if (!_importContacts.length) return;
 
@@ -365,21 +422,12 @@ async function startImport() {
 
   for (let i = 0; i < _importContacts.length; i += BATCH) {
     const chunk = _importContacts.slice(i, i + BATCH);
-    await new Promise(resolve => {
-      chrome.runtime.sendMessage({ action: 'batchImportContacts', contacts: chunk }, resp => {
-        if (resp && resp.ok && resp.data) {
-          okTotal += resp.data.summary.ok;
-          failTotal += resp.data.summary.fail;
-        } else {
-          failTotal += chunk.length;
-        }
-        done += chunk.length;
-        const pct = Math.round((done / _importContacts.length) * 100);
-        barEl.style.width = pct + '%';
-        statusEl.textContent = `${done}/${_importContacts.length} enviados...`;
-        resolve();
-      });
-    });
+    const result = await _sendChunkWithRetry(chunk);
+    okTotal += result.summary.ok;
+    failTotal += result.summary.fail;
+    done += chunk.length;
+    barEl.style.width = Math.round((done / _importContacts.length) * 100) + '%';
+    statusEl.textContent = `${done}/${_importContacts.length} enviados...`;
   }
 
   document.getElementById('bl-import-progress').style.display = 'none';

--- a/sidepanel/modules/batchLeads.js
+++ b/sidepanel/modules/batchLeads.js
@@ -215,6 +215,12 @@ let _lastStatusTs = 0;
 function _startProgressPolling() {
   if (_pollInterval) clearInterval(_pollInterval);
   _pollInterval = setInterval(() => {
+    // Auto-stop if the batch leads view was replaced by another view
+    if (!document.getElementById('bl-progress')) {
+      clearInterval(_pollInterval);
+      _pollInterval = null;
+      return;
+    }
     chrome.storage.session.get(['batchExtractStatus'], result => {
       const s = result.batchExtractStatus;
       if (!s || s.ts === _lastStatusTs) return;
@@ -270,15 +276,45 @@ function downloadCSV() {
 // ================================================================
 //  CSV IMPORT
 // ================================================================
+function _escHtml(s) {
+  return String(s || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+}
+
+function _parseCSVLine(line) {
+  // Handles RFC 4180: fields may be quoted, commas inside quotes are preserved
+  const fields = [];
+  let i = 0;
+  while (i < line.length) {
+    if (line[i] === '"') {
+      let val = '';
+      i++; // skip opening quote
+      while (i < line.length) {
+        if (line[i] === '"' && line[i + 1] === '"') { val += '"'; i += 2; }
+        else if (line[i] === '"') { i++; break; }
+        else { val += line[i++]; }
+      }
+      fields.push(val);
+      if (line[i] === ',') i++; // skip comma after field
+    } else {
+      const end = line.indexOf(',', i);
+      if (end === -1) { fields.push(line.slice(i)); break; }
+      fields.push(line.slice(i, end));
+      i = end + 1;
+    }
+  }
+  return fields;
+}
+
 function parseCSV(text) {
   const lines = text.trim().split(/\r?\n/);
   if (lines.length < 2) return [];
-  // Detect header
   const firstLine = lines[0].toLowerCase();
   const startIdx = (firstLine.includes('telefone') || firstLine.includes('phone')) ? 1 : 0;
   return lines.slice(startIdx).map(line => {
-    const [phone, ...rest] = line.split(',');
-    return { phone: (phone || '').trim().replace(/\D/g, ''), name: rest.join(' ').trim() };
+    const fields = _parseCSVLine(line);
+    const phone = (fields[0] || '').trim().replace(/\D/g, '');
+    const name = (fields[1] || '').trim();
+    return { phone, name };
   }).filter(c => c.phone.length >= 7);
 }
 
@@ -301,8 +337,8 @@ function showImportPreview() {
   countEl.textContent = `${_importContacts.length} contatos carregados`;
   tbody.innerHTML = _importContacts.slice(0, 50).map(c => `
     <tr>
-      <td style="padding:3px 8px;border-top:1px solid #F3F4F6;">${c.phone}</td>
-      <td style="padding:3px 8px;border-top:1px solid #F3F4F6;">${c.name || '—'}</td>
+      <td style="padding:3px 8px;border-top:1px solid #F3F4F6;">${_escHtml(c.phone)}</td>
+      <td style="padding:3px 8px;border-top:1px solid #F3F4F6;">${_escHtml(c.name) || '—'}</td>
     </tr>
   `).join('');
   if (_importContacts.length > 50) {

--- a/sidepanel/modules/batchLeads.js
+++ b/sidepanel/modules/batchLeads.js
@@ -254,10 +254,9 @@ function _startProgressPolling() {
 // ================================================================
 function downloadCSV() {
   if (!_extractedContacts.length) return;
+  const csvField = v => `"${(v || '').replace(/"/g, '""')}"`;
   const rows = [['telefone', 'nome']];
-  _extractedContacts.forEach(c => {
-    rows.push([c.phone, (c.name || '').replace(/,/g, ' ')]);
-  });
+  _extractedContacts.forEach(c => rows.push([c.phone, csvField(c.name)]));
   const csv = rows.map(r => r.join(',')).join('\n');
   const blob = new Blob(['\uFEFF' + csv], { type: 'text/csv;charset=utf-8;' });
   const url = URL.createObjectURL(blob);

--- a/sidepanel/modules/batchLeads.js
+++ b/sidepanel/modules/batchLeads.js
@@ -204,6 +204,12 @@ function startExtraction() {
   bar.style.animation = 'bl-pulse 1.2s ease-in-out infinite';
   document.getElementById('bl-stop-btn').style.display = '';
 
+  // Ignore any stale completion event left in session storage from a previous run.
+  _lastStatusTs = Date.now();
+  // Polling stops itself when the previous extraction completes — restart it here so
+  // a second extraction in the same view still updates progress and result.
+  _startProgressPolling();
+
   const cutoffMs = periodToCutoffMs(getSelectedPeriod());
   chrome.runtime.sendMessage({ action: 'batchExtractStart', cutoffMs }, (resp) => {
     if (resp && !resp.ok) {

--- a/sidepanel/modules/batchLeads.js
+++ b/sidepanel/modules/batchLeads.js
@@ -1,0 +1,358 @@
+/* ============================================================
+   Q10 CRM — Batch Leads Module
+   Extracts contacts from WhatsApp Web chat list → CSV download
+   and imports a CSV file → Q10 /contactos (batch)
+   ============================================================ */
+
+// ================================================================
+//  RENDER
+// ================================================================
+export function renderBatchLeads() {
+  const body = document.getElementById('q10-body');
+  const actions = document.getElementById('q10-actions');
+  actions.style.display = 'none';
+  actions.innerHTML = '';
+
+  body.innerHTML = `
+    <div style="padding:16px;display:flex;flex-direction:column;gap:16px;">
+
+      <!-- SECTION 1: Extract -->
+      <div style="background:#fff;border-radius:10px;padding:14px;box-shadow:0 1px 4px rgba(0,0,0,.08);">
+        <div style="font-weight:600;font-size:13px;color:#0369A1;margin-bottom:10px;">
+          1. Extrair contatos do WhatsApp Web
+        </div>
+
+        <div style="font-size:12px;color:#6B7280;margin-bottom:10px;">
+          Período das conversas:
+        </div>
+        <div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:12px;" id="bl-period-btns">
+          ${['3m','6m','1a','Tudo'].map((v, i) => `
+            <button class="bl-period${i===0?' bl-period-active':''}" data-period="${v}"
+              style="padding:5px 10px;border-radius:20px;border:1.5px solid ${i===0?'#0EA5E9':'#D1D5DB'};
+                     background:${i===0?'#EFF6FF':'#fff'};color:${i===0?'#0369A1':'#374151'};
+                     font-size:12px;font-weight:500;cursor:pointer;">
+              ${v}
+            </button>`).join('')}
+        </div>
+
+        <button id="bl-extract-btn"
+          style="width:100%;padding:9px;background:#0EA5E9;color:#fff;border:none;border-radius:8px;
+                 font-size:13px;font-weight:600;cursor:pointer;display:flex;align-items:center;justify-content:center;gap:6px;">
+          <span>&#9654;</span> Extrair Contatos
+        </button>
+
+        <div id="bl-progress" style="display:none;margin-top:10px;">
+          <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:4px;">
+            <span style="font-size:12px;color:#374151;" id="bl-progress-label">Buscando...</span>
+            <button id="bl-stop-btn"
+              style="font-size:11px;color:#EF4444;background:none;border:1px solid #EF4444;
+                     border-radius:6px;padding:2px 8px;cursor:pointer;">
+              &#9632; Parar
+            </button>
+          </div>
+          <div style="height:6px;background:#E5E7EB;border-radius:3px;overflow:hidden;">
+            <div id="bl-progress-bar"
+              style="height:100%;background:#0EA5E9;width:20%;border-radius:3px;
+                     animation:bl-pulse 1.2s ease-in-out infinite;"></div>
+          </div>
+        </div>
+
+        <div id="bl-result" style="display:none;margin-top:10px;">
+          <div style="font-size:12px;color:#059669;font-weight:500;" id="bl-result-label"></div>
+          <button id="bl-csv-btn"
+            style="margin-top:8px;width:100%;padding:9px;background:#059669;color:#fff;border:none;
+                   border-radius:8px;font-size:13px;font-weight:600;cursor:pointer;">
+            &#8595; Baixar CSV
+          </button>
+        </div>
+      </div>
+
+      <!-- SECTION 2: Import CSV -->
+      <div style="background:#fff;border-radius:10px;padding:14px;box-shadow:0 1px 4px rgba(0,0,0,.08);">
+        <div style="font-weight:600;font-size:13px;color:#0369A1;margin-bottom:10px;">
+          2. Importar CSV para Q10
+        </div>
+        <div style="font-size:11px;color:#9CA3AF;margin-bottom:8px;">
+          Colunas esperadas: <code>telefone,nome</code>
+        </div>
+        <label style="display:block;border:1.5px dashed #D1D5DB;border-radius:8px;padding:12px;
+                      text-align:center;cursor:pointer;font-size:12px;color:#6B7280;">
+          <input type="file" id="bl-csv-input" accept=".csv" style="display:none;">
+          &#128194; Selecionar arquivo CSV
+        </label>
+
+        <div id="bl-import-preview" style="display:none;margin-top:10px;">
+          <div style="font-size:12px;color:#374151;font-weight:500;margin-bottom:6px;"
+               id="bl-import-count"></div>
+          <div style="max-height:120px;overflow-y:auto;border:1px solid #E5E7EB;border-radius:6px;">
+            <table style="width:100%;border-collapse:collapse;font-size:11px;" id="bl-import-table">
+              <thead>
+                <tr style="background:#F3F4F6;">
+                  <th style="padding:4px 8px;text-align:left;color:#6B7280;">Telefone</th>
+                  <th style="padding:4px 8px;text-align:left;color:#6B7280;">Nome</th>
+                </tr>
+              </thead>
+              <tbody id="bl-import-tbody"></tbody>
+            </table>
+          </div>
+          <button id="bl-import-btn"
+            style="margin-top:8px;width:100%;padding:9px;background:#7C3AED;color:#fff;border:none;
+                   border-radius:8px;font-size:13px;font-weight:600;cursor:pointer;">
+            &#9654; Enviar para Q10
+          </button>
+        </div>
+
+        <div id="bl-import-progress" style="display:none;margin-top:10px;">
+          <div style="height:6px;background:#E5E7EB;border-radius:3px;overflow:hidden;">
+            <div id="bl-import-bar"
+              style="height:100%;background:#7C3AED;width:0%;border-radius:3px;transition:width .3s;"></div>
+          </div>
+          <div style="font-size:12px;color:#374151;margin-top:4px;" id="bl-import-status"></div>
+        </div>
+
+        <div id="bl-import-done" style="display:none;margin-top:10px;font-size:12px;"></div>
+      </div>
+
+    </div>
+
+    <style>
+      .bl-period-active { border-color:#0EA5E9!important; background:#EFF6FF!important; color:#0369A1!important; }
+      @keyframes bl-pulse { 0%,100%{opacity:1} 50%{opacity:.4} }
+    </style>
+  `;
+
+  bindBatchLeadsEvents();
+}
+
+// ================================================================
+//  EVENTS
+// ================================================================
+let _extractedContacts = [];
+let _importContacts = [];
+
+function bindBatchLeadsEvents() {
+  // Period selector
+  document.getElementById('bl-period-btns').addEventListener('click', e => {
+    const btn = e.target.closest('.bl-period');
+    if (!btn) return;
+    document.querySelectorAll('.bl-period').forEach(b => {
+      b.classList.remove('bl-period-active');
+      b.style.borderColor = '#D1D5DB';
+      b.style.background = '#fff';
+      b.style.color = '#374151';
+    });
+    btn.classList.add('bl-period-active');
+    btn.style.borderColor = '#0EA5E9';
+    btn.style.background = '#EFF6FF';
+    btn.style.color = '#0369A1';
+  });
+
+  // Extract button
+  document.getElementById('bl-extract-btn').addEventListener('click', startExtraction);
+
+  // Stop button
+  document.getElementById('bl-stop-btn').addEventListener('click', stopExtraction);
+
+  // CSV download button (set later when data is ready)
+  document.getElementById('bl-csv-btn').addEventListener('click', downloadCSV);
+
+  // CSV file input
+  document.getElementById('bl-csv-input').addEventListener('change', onCSVFileSelected);
+
+  // Import button
+  document.getElementById('bl-import-btn').addEventListener('click', startImport);
+
+  // Start polling for extraction progress
+  _startProgressPolling();
+}
+
+// ================================================================
+//  EXTRACTION
+// ================================================================
+function getSelectedPeriod() {
+  const active = document.querySelector('.bl-period-active');
+  return active?.dataset?.period || 'Tudo';
+}
+
+function periodToCutoffMs(period) {
+  const now = Date.now();
+  const map = { '3m': 90, '6m': 180, '1a': 365 };
+  const days = map[period];
+  if (!days) return null; // "Tudo" = no cutoff
+  return now - days * 24 * 60 * 60 * 1000;
+}
+
+function startExtraction() {
+  const period = getSelectedPeriod();
+  const cutoffMs = periodToCutoffMs(period);
+
+  _extractedContacts = [];
+
+  document.getElementById('bl-extract-btn').disabled = true;
+  document.getElementById('bl-extract-btn').style.opacity = '0.6';
+  document.getElementById('bl-progress').style.display = 'block';
+  document.getElementById('bl-result').style.display = 'none';
+  document.getElementById('bl-progress-label').textContent = 'Iniciando...';
+
+  chrome.runtime.sendMessage({ action: 'batchExtractStart', cutoffMs }, (resp) => {
+    if (resp && !resp.ok) {
+      stopExtraction();
+      document.getElementById('bl-progress-label').textContent = resp.error || 'Erro ao iniciar';
+    }
+  });
+}
+
+function stopExtraction() {
+  chrome.runtime.sendMessage({ action: 'batchExtractStop' });
+  document.getElementById('bl-extract-btn').disabled = false;
+  document.getElementById('bl-extract-btn').style.opacity = '1';
+  document.getElementById('bl-progress').style.display = 'none';
+}
+
+let _pollInterval = null;
+let _lastStatusTs = 0;
+
+function _startProgressPolling() {
+  if (_pollInterval) clearInterval(_pollInterval);
+  _pollInterval = setInterval(() => {
+    chrome.storage.session.get(['batchExtractStatus'], result => {
+      const s = result.batchExtractStatus;
+      if (!s || s.ts === _lastStatusTs) return;
+      _lastStatusTs = s.ts;
+
+      if (s.action === 'batchExtractProgress') {
+        const label = document.getElementById('bl-progress-label');
+        if (label) label.textContent = `${s.count} contatos encontrados...`;
+      }
+
+      if (s.action === 'batchExtractComplete') {
+        clearInterval(_pollInterval);
+        document.getElementById('bl-extract-btn').disabled = false;
+        document.getElementById('bl-extract-btn').style.opacity = '1';
+        document.getElementById('bl-progress').style.display = 'none';
+
+        if (s.ok && s.data) {
+          _extractedContacts = s.data;
+          document.getElementById('bl-result').style.display = 'block';
+          document.getElementById('bl-result-label').textContent =
+            `✓ ${s.data.length} contatos extraídos`;
+        } else {
+          document.getElementById('bl-progress').style.display = 'block';
+          document.getElementById('bl-progress-label').textContent =
+            s.error || 'Extração falhou';
+          document.getElementById('bl-stop-btn').style.display = 'none';
+          document.getElementById('bl-progress-bar').style.animationName = 'none';
+          document.getElementById('bl-progress-bar').style.background = '#EF4444';
+        }
+      }
+    });
+  }, 600);
+}
+
+// ================================================================
+//  CSV DOWNLOAD
+// ================================================================
+function downloadCSV() {
+  if (!_extractedContacts.length) return;
+  const rows = [['telefone', 'nome']];
+  _extractedContacts.forEach(c => {
+    rows.push([c.phone, (c.name || '').replace(/,/g, ' ')]);
+  });
+  const csv = rows.map(r => r.join(',')).join('\n');
+  const blob = new Blob(['\uFEFF' + csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `leads_whatsapp_${new Date().toISOString().slice(0,10)}.csv`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+// ================================================================
+//  CSV IMPORT
+// ================================================================
+function parseCSV(text) {
+  const lines = text.trim().split(/\r?\n/);
+  if (lines.length < 2) return [];
+  // Detect header
+  const firstLine = lines[0].toLowerCase();
+  const startIdx = (firstLine.includes('telefone') || firstLine.includes('phone')) ? 1 : 0;
+  return lines.slice(startIdx).map(line => {
+    const [phone, ...rest] = line.split(',');
+    return { phone: (phone || '').trim().replace(/\D/g, ''), name: rest.join(' ').trim() };
+  }).filter(c => c.phone.length >= 7);
+}
+
+function onCSVFileSelected(e) {
+  const file = e.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = ev => {
+    _importContacts = parseCSV(ev.target.result);
+    showImportPreview();
+  };
+  reader.readAsText(file, 'UTF-8');
+}
+
+function showImportPreview() {
+  const preview = document.getElementById('bl-import-preview');
+  const tbody = document.getElementById('bl-import-tbody');
+  const countEl = document.getElementById('bl-import-count');
+
+  countEl.textContent = `${_importContacts.length} contatos carregados`;
+  tbody.innerHTML = _importContacts.slice(0, 50).map(c => `
+    <tr>
+      <td style="padding:3px 8px;border-top:1px solid #F3F4F6;">${c.phone}</td>
+      <td style="padding:3px 8px;border-top:1px solid #F3F4F6;">${c.name || '—'}</td>
+    </tr>
+  `).join('');
+  if (_importContacts.length > 50) {
+    tbody.innerHTML += `<tr><td colspan="2" style="padding:4px 8px;color:#9CA3AF;font-size:11px;">
+      ... e mais ${_importContacts.length - 50} contatos</td></tr>`;
+  }
+  preview.style.display = 'block';
+}
+
+async function startImport() {
+  if (!_importContacts.length) return;
+
+  document.getElementById('bl-import-btn').disabled = true;
+  document.getElementById('bl-import-progress').style.display = 'block';
+  document.getElementById('bl-import-done').style.display = 'none';
+
+  const BATCH = 10;
+  let done = 0;
+  let okTotal = 0;
+  let failTotal = 0;
+
+  const statusEl = document.getElementById('bl-import-status');
+  const barEl = document.getElementById('bl-import-bar');
+
+  for (let i = 0; i < _importContacts.length; i += BATCH) {
+    const chunk = _importContacts.slice(i, i + BATCH);
+    await new Promise(resolve => {
+      chrome.runtime.sendMessage({ action: 'batchImportContacts', contacts: chunk }, resp => {
+        if (resp && resp.ok && resp.data) {
+          okTotal += resp.data.summary.ok;
+          failTotal += resp.data.summary.fail;
+        } else {
+          failTotal += chunk.length;
+        }
+        done += chunk.length;
+        const pct = Math.round((done / _importContacts.length) * 100);
+        barEl.style.width = pct + '%';
+        statusEl.textContent = `${done}/${_importContacts.length} enviados...`;
+        resolve();
+      });
+    });
+  }
+
+  document.getElementById('bl-import-progress').style.display = 'none';
+  document.getElementById('bl-import-btn').disabled = false;
+  const doneEl = document.getElementById('bl-import-done');
+  doneEl.style.display = 'block';
+  doneEl.innerHTML = `
+    <span style="color:#059669;font-weight:600;">✓ ${okTotal} importados</span>
+    ${failTotal ? `<span style="color:#EF4444;margin-left:8px;">✗ ${failTotal} falhas</span>` : ''}
+  `;
+}

--- a/sidepanel/sidepanel.html
+++ b/sidepanel/sidepanel.html
@@ -18,6 +18,11 @@
           <div class="q10-header-subtitle">Genius Idiomas</div>
         </div>
       </div>
+      <button id="btn-batch-leads" title="Importar leads antigos"
+        style="background:rgba(255,255,255,0.15);border:none;border-radius:8px;padding:6px 10px;
+               color:white;cursor:pointer;font-size:11px;font-weight:600;white-space:nowrap;">
+        &#9776; Leads
+      </button>
     </div>
     <div class="q10-body" id="q10-body"></div>
     <div class="q10-actions" id="q10-actions" style="display:none;"></div>

--- a/sidepanel/sidepanel.js
+++ b/sidepanel/sidepanel.js
@@ -34,6 +34,10 @@
     Object.keys(m).forEach(k => window['_' + k] = m[k]);
   });
 
+  import('./modules/batchLeads.js').then(m => {
+    window._renderBatchLeads = m.renderBatchLeads;
+  });
+
   // ================================================================
   //  BRIDGE HELPERS — expose module functions to DOM inline handlers
   //  These replace the old inline <script> snippets that called
@@ -154,6 +158,13 @@
     check();
   }
 
-  waitForModules(init);
+  waitForModules(() => {
+    init();
+
+    // Batch leads button — available regardless of current view
+    document.getElementById('btn-batch-leads')?.addEventListener('click', () => {
+      if (window._renderBatchLeads) window._renderBatchLeads();
+    });
+  });
 
 })();


### PR DESCRIPTION
## Summary
- Adds **\"≡ Leads\"** button in the sidepanel header that opens a batch import view
- Plugin scrolls the WhatsApp Web chat list automatically, collecting all contact names and phone numbers (with optional cutoff period: 3m / 6m / 1a / Tudo)
- Extracted contacts can be downloaded as a **CSV file** for review/editing before import
- CSV can be re-uploaded to the plugin for a **batch POST to Q10 /contactos**, with progress bar and success/failure summary

## Architecture
- `content/content.js` — added `runBatchExtraction()`: scrolls `#pane-side`, reads `data-id` attributes, sends progress via `chrome.runtime`
- `background/service-worker.js` — relays `batchExtractStart/Stop` to the WhatsApp tab; stores progress in `chrome.storage.session`; handles `batchImportContacts` (batch POST loop)
- `sidepanel/modules/batchLeads.js` (new) — full UI: period selector, progress bar, CSV download, CSV upload preview, import to Q10
- `sidepanel/sidepanel.html` + `sidepanel.js` — wires up the Leads button

## Test Plan
- [ ] Load extension on WhatsApp Web with conversations
- [ ] Click "≡ Leads" button in the panel header
- [ ] Select a period and click "Extrair Contatos" — verify scroll starts and count increments
- [ ] Click "Parar" — verify scroll stops
- [ ] Click "Baixar CSV" — verify file downloads with correct columns
- [ ] Re-upload the CSV — verify preview table shows contacts
- [ ] Click "Enviar para Q10" — verify contacts appear in Q10 /contactos
- [ ] All 64 unit tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)