### PR TITLE
fix: lead-first batch import — POST /oportunidades before /contactos

### DIFF
--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -540,29 +540,54 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     case 'batchImportContacts':
       return handle((async () => {
         const contacts = msg.contacts || [];
+        // Q10 forbids standalone /contactos — POST /oportunidades first, then
+        // attach the contacto via the returned Consecutivo_oportunidad. Probe:
+        // POST /contactos {Consecutivo_oportunidad:0} → 404 "no se encontró
+        // una oportunidad"; omitting the field → 400 "obligatorio".
+        const asesorId = await getAsesorId();
         const results = [];
+        let abortReason = null;
         for (const c of contacts) {
+          if (abortReason) {
+            results.push({ phone: c.phone, ok: false, error: abortReason });
+            continue;
+          }
+          const phone = (c.phone || '').replace(/\D/g, '').slice(-12);
           try {
             const nameParts = (c.name || '').trim().split(/\s+/);
             const firstName = nameParts[0] || 'Contato';
             const lastName = nameParts.slice(1).join(' ') || 'WhatsApp';
-            const phone = (c.phone || '').replace(/\D/g, '');
-            const body = {
-              Consecutivo_oportunidad: 0,
+            const displayName = (c.name || '').trim() || phone || 'Contato WhatsApp';
+            const oportunidadBody = {
+              Nombre_oportunidad: displayName,
+              Numero_identificacion_oportunidad: displayName,
+            };
+            if (asesorId) oportunidadBody.Numero_identificacion_asesor = asesorId;
+            const oportunidad = await apiPost('/oportunidades', oportunidadBody);
+            const consecutivo = oportunidad?.Consecutivo_oportunidad ?? oportunidad?.Consecutivo;
+            if (!consecutivo) throw new Error('Resposta de /oportunidades sem Consecutivo_oportunidad');
+            const contactoBody = {
+              Consecutivo_oportunidad: consecutivo,
               Nombres: firstName,
               Apellidos: lastName,
-              Detalle: [{ Tipo_detalle: 'Celular', Descripcion: phone }]
+              Detalle: phone ? [{ Tipo_detalle: 'Celular', Descripcion: phone }] : [],
             };
-            await apiPost('/contactos', body);
+            await apiPost('/contactos', contactoBody);
             results.push({ phone, ok: true });
           } catch (e) {
-            results.push({ phone: c.phone, ok: false, error: e.message });
+            const errMsg = e.message || '';
+            if (/no se encuentra registrado un asesor/i.test(errMsg)) {
+              abortReason = 'O asesor configurado nas Opções não está cadastrado como asesor no Q10. Vá em Q10 → Mercadeo → Asesores. Importação interrompida.';
+              results.push({ phone: c.phone, ok: false, error: abortReason });
+            } else {
+              results.push({ phone: c.phone, ok: false, error: errMsg });
+            }
           }
         }
         const ok = results.filter(r => r.ok).length;
         const fail = results.filter(r => !r.ok).length;
         if (ok > 0) cache.clear();
-        return { results, summary: { ok, fail } };
+        return { results, summary: { ok, fail }, fatalError: abortReason };
       })());
 
     default:


### PR DESCRIPTION
## Summary
- `batchImportContacts` was POSTing `/contactos` with `Consecutivo_oportunidad: 0` for every WhatsApp row → Q10 returns 404 "No se encontró una oportunidad". Every row failed silently in the per-row try/catch.
- Now mirrors the working `createOportunidad` SW pattern: per row, POST `/oportunidades` first (asesor auto-injected), then POST `/contactos` linked to the returned `Consecutivo_oportunidad`.
- On `"no se encuentra registrado un asesor"`, abort the rest of the batch — same global config error would fail every row. Returns `fatalError` in the response (additive — current consumer only reads `summary.ok/fail`).

## Test plan
- [ ] Carregar CSV com 2-3 contatos válidos via Batch Leads → verificar que aparecem em Q10 → Mercadeo → Oportunidades + Contactos linkados
- [ ] Configurar asesor inválido nas Opções → rodar import → primeiro row retorna a mensagem amigável, demais ficam marcados com o mesmo motivo (sem hammering na API)
- [ ] Linha sem nome (só telefone) → display name cai pro telefone, oportunidade criada
- [ ] Verificar que `summary.ok/fail` continuam corretos no log da progress bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)